### PR TITLE
quality mapping to old names

### DIFF
--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -34,8 +34,8 @@ SWN.itemLocations = {
 
 SWN.itemQualities = {
   stock: 'swnr.item.quality.stock',
-  makeshift: 'swnr.item.quality.juryRigged',
-  masterwork: 'swnr.item.quality.mastercrafted',
+  juryRigged: 'swnr.item.quality.juryRigged',
+  mastercrafted: 'swnr.item.quality.mastercrafted',
 }
 
 SWN.ammoTypes = {


### PR DESCRIPTION
bug reported by @Torticute on discord. this should allow juryRigged and mastercrafted item qualities to be supported