### PR TITLE
Fix skill boosts damage bug

### DIFF
--- a/module/data/items/item-weapon.mjs
+++ b/module/data/items/item-weapon.mjs
@@ -315,7 +315,7 @@ export default class SWNWeapon extends SWNBaseGearItem {
       }
 
       if (actor?.type == "character") {
-        dmgBonus = this.skillBoostsDamage ? skill.rank : 0;
+        dmgBonus = this.skillBoostsDamage ? skill.system.rank : 0;
       }
       return this.rollAttack(
         dmgBonus,


### PR DESCRIPTION
The skill bonus is not properly assigned to the role if the skillboostsdamage option is enabled.