### PR TITLE
Dev 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the Systems Without Number Redux (SWNR) system for Foundr
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] 2025-11-04 More XWN support
+- Added stress button to character sheet TODO 
+
 ## [2.2.0] 2025-11-03 More AWN support
 
 ### Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added stress button to character sheet to modify and roll stress, along with tracking breakdowns (page 57 of AWN).
 - Auto show power type on features tab when first added
 - Setting to not roll damage/trauma dice on attack roll automatically with button to roll
+- Added GM notes to item description (under description tab). GM notes are hidden by default and can be shown to players by checking the box.
 
 ## [2.2.1] 2025-11-11 CWN Cyberware compendium
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom currency system configuration supported. Base currency and up to 5 custom currencies.
 - Added readied and stowed modifiers to character sheet (under features/tweaks)
 - Fixed capt support department bug
+- Added stress button to character sheet to modify and roll stress, along with tracking breakdowns (page 57 of AWN).
 - Auto show power type on features tab when first added
 - Setting to not roll damage/trauma dice on attack roll automatically with button to roll
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.3.0] 2025-11-04 More XWN support
 
-- Custom currency system configuration supported. Base currency and up to 5 custom currencies.
+- Custom currency system configuration supported. Base currency and up to 5 custom currencies. Old debt, balance, and owed fields are deprecated and will be removed in a future version.  They should be migrated to the new system, but the old values are shown in the tweaks section as readonly.
 - Added readied and stowed modifiers to character sheet (under features/tweaks)
 - Fixed capt support department bug
 - Added stress button to character sheet to modify and roll stress, along with tracking breakdowns (page 57 of AWN).
-- Auto show power type on features tab when first added
+- Auto show power type on features tab when type is first added
 - Setting to not roll damage/trauma dice on attack roll automatically with button to roll
 - Added GM notes to item description (under description tab). GM notes are hidden by default and can be shown to players by checking the box.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom currency system configuration supported. Base currency and up to 5 custom currencies.
 - Added readied and stowed modifiers to character sheet (under features/tweaks)
 - Fixed capt support department bug
+- Auto show power type on features tab when first added
+- Setting to not roll damage/trauma dice on attack roll automatically with button to roll
 
 ## [2.2.0] 2025-11-03 More AWN support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.3.0] 2025-11-04 More XWN support
-- Added stress button to character sheet TODO 
+- Added readied and stowed modifiers to character sheet (under features/tweaks)
+- Fixed capt support department bug
 
 ## [2.2.0] 2025-11-03 More AWN support
 
@@ -21,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issues for ship / mech attack
 - Removed roll formula from item description by default
 - Updated WWN / OSE compendium content
-- Updated NPC import from CSV
+- Updated NPC import from CSV for compendium import
 - Added condition to item description and chat messages. Not yet automated. Behind AWN setting.
 - Shock damage now uses dice string
 - Changed several fields to validate that they are valid dice strings (such as damage, trauma, etc)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.3.0] 2025-11-04 More XWN support
+
+- Custom currency system configuration supported. Base currency and up to 5 custom currencies.
 - Added readied and stowed modifiers to character sheet (under features/tweaks)
 - Fixed capt support department bug
 

--- a/css/swnr.css
+++ b/css/swnr.css
@@ -222,6 +222,13 @@
   margin-top: 4px;
 }
 
+.chat-message .flex-center {
+  display: flex;
+  justify-content: center; /* centers horizontally */
+  align-items: center; /* centers vertically (optional) */
+  margin-top: 0.5em; /* optional spacing */
+}
+
 .chat-message .power-usage .resource-cost {
   background: var(--color-bg-btn);
   border: 1px solid var(--color-border-dark-tertiary);
@@ -751,6 +758,32 @@
 .swnr .item-form {
   font-family: "Roboto", sans-serif;
 }
+.swnr .gap-2 {
+  gap: 2px;
+}
+.swnr .gap-4 {
+  gap: 4px;
+}
+.swnr .settings-form {
+  overflow-y: auto; /* vertical scrollbar */
+  overflow-x: hidden; /* optional */
+  padding-right: 0.5em; /* space for scrollbar */
+}
+.swnr .settings-form .custom-currency-container {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: 1px solid var(--border-color);
+  border-radius: 2px;
+  padding: 4px;
+  margin: 4px;
+}
+.swnr .settings-form .custom-currency-container .h4 {
+  margin-bottom: 1rem;
+}
+.swnr .settings-form .h4 {
+  margin-bottom: 1rem;
+}
 .swnr .sheet-header {
   flex: 0 auto;
   /* overflow: hidden; TODO */
@@ -768,7 +801,6 @@
 }
 .swnr .sheet-header input[type=text],
 .swnr .sheet-header input[type=number],
-.swnr .sheet-header select,
 .swnr .sheet-header div.field {
   font-size: 14px;
   /* padding: 2px; */
@@ -785,12 +817,29 @@
   user-select: text;
   transition: outline-color 0.5s;
   min-width: 20px;
+  box-shadow: none;
+}
+.swnr .sheet-header select {
+  font-size: 14px;
+  /* padding: 2px; */
+  margin: 2px;
+  border: none;
+  border-radius: 0;
+  /* background: var(--swnr-c-white); */
+  background: none;
+  color: var(--swnr-c-dark);
+  outline: 1px solid transparent;
+  height: var(--input-height);
+  line-height: var(--input-height);
+  user-select: text;
+  transition: outline-color 0.5s;
+  min-width: 20px;
 }
 .swnr .sheet-header .profile-img,
 .swnr .sheet-header .item-img {
-  width: 150px;
-  max-width: 150px;
-  height: 150px;
+  width: 130px;
+  max-width: 130px;
+  height: 130px;
   border-radius: 50%;
   border: 1px solid var(--border-color);
   box-shadow: 0 0 10px inset rgba(0, 0, 0, 0.4);
@@ -825,7 +874,7 @@
 }
 .swnr .sheet-header .thin-bar {
   margin-top: -5px;
-  margin-bottom: -15px;
+  margin-bottom: -10px;
 }
 .swnr .sheet-header .header-fields {
   flex: 1;
@@ -850,6 +899,7 @@
   outline: none;
   color: inherit;
   font-size: inherit;
+  text-align: center;
   width: calc(50% - 30px);
   height: 100%;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1497,6 +1497,11 @@
       }
     },
     "sheet": {
+      "addCurrency": "Add Currency",
+      "editCurrency": "Edit Currency",
+      "deleteCurrency": "Delete Currency",
+      "convertToBaseCurrency": "Convert to Base Currency",
+      "addCurrencyHint": "Add a new currency to the character.",
       "background": "Background",
       "class": "Class",
       "homeworld": "Home world",

--- a/lang/en.json
+++ b/lang/en.json
@@ -210,6 +210,14 @@
               "mod": {
                 "label": "Initiative Mod"
               }
+            },
+            "modifiers": {
+              "readied": {
+                "label": "Readied Modifier"
+              },
+              "stowed": {
+                "label": "Stowed Modifier"
+              }
             }
           },
           "class": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1957,6 +1957,8 @@
       "tweaks": "Tweaks"
     },
     "settings": {
+      "damageRoll": "Auto Damage Roll",
+      "damageRollHint": "Automatically roll damage for attacks?",
       "currency": {
         "title": "Currency Settings",
         "titleHint": "Configure the currencies for the world.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1952,6 +1952,14 @@
       "tweaks": "Tweaks"
     },
     "settings": {
+      "currency": {
+        "title": "Currency Settings",
+        "titleHint": "Configure the currencies for the world.",
+        "baseName": "Base Currency Name",
+        "baseNameHint": "The name of the base currency for the world.",
+        "baseEnc": "Base Currency Encumbrance",
+        "baseEncHint": "The number of base currency units that take up one slot. 0 = no encumbrance."
+      },
       "useRollNPCHD": "Use NPC HD on token create?",
       "useRollNPCHDHint": "When creating a npc token, if the HP or Hit Dice (HD) has not been rolled, it will roll d8 HD for health automatically.",
       "useHomebrewLuckSave": "Use Homebrew Luck saves?",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1958,7 +1958,13 @@
         "baseName": "Base Currency Name",
         "baseNameHint": "The name of the base currency for the world.",
         "baseEnc": "Base Currency Encumbrance",
-        "baseEncHint": "The number of base currency units that take up one slot. 0 = no encumbrance."
+        "baseEncHint": "The number of base currency units that take up one slot. 0 = no encumbrance.",
+        "customName": "Custom Currency Name",
+        "customNameHint": "The name of the custom currency for the world. Blank (leave empty) to disable",
+        "customEnc": "Currency Encumbrance",
+        "customEncHint": "The number of custom currency units that take up one slot. 0 = no encumbrance.",
+        "customConversionRate": "Conversion Rate",
+        "customConversionRateHint": "The conversion rate to the base currency. 0 means is not convertible. > 0 means the custom currency is worth less than the base currency. < 0 means the custom currency is worth more than the base currency (e.g., -10 means 1 converts to 10 base currency units)."
       },
       "useRollNPCHD": "Use NPC HD on token create?",
       "useRollNPCHDHint": "When creating a npc token, if the HP or Hit Dice (HD) has not been rolled, it will roll d8 HD for health automatically.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1616,6 +1616,7 @@
       "rest-desc": "Apply a good night's rest (reset effort, drop strain, heal HP)?",
       "rest-title": "Apply a Good Night's Rest?",
       "none": "None",
+      "stressLong": "Stress (Breakdown Checks)",
       "cyberware": {
         "disabled": "Disabled",
         "strain": "Strain",

--- a/module/data/actors/actor-character.mjs
+++ b/module/data/actors/actor-character.mjs
@@ -256,6 +256,30 @@ export default class SWNCharacter extends SWNActorBase {
       .map(itemInvCost)
       .reduce((i, n) => i + n, 0);
 
+    const baseCurrencyEnc = game.settings.get("swnr", "baseCurrencyEnc");
+
+    // calculate stowed encumbrance from currency
+    if (baseCurrencyEnc > 0) {
+      const baseCurrency = this.credits.carriedBase;
+      const baseCurrencyValue = Math.floor(baseCurrency / baseCurrencyEnc);
+      encumbrance.stowed.value += baseCurrencyValue;
+    }
+    for (let currency of this.credits.extraCurrencies) {
+      if (currency.type !== 'base') {
+        const currencyEnc = game.settings.get("swnr", `customCurrencyEnc${currency.type}`);
+        if (currencyEnc > 0) {
+          const currencyValue = Math.floor(currency.value / currencyEnc);
+          encumbrance.stowed.value += currencyValue;
+        }
+      } else if (baseCurrencyEnc > 0) {
+        // more base 
+        const currencyValue = Math.floor(currency.value / baseCurrencyEnc);
+        encumbrance.stowed.value += currencyValue;
+      } else {
+        // Base has no encumbrance
+      }
+    }
+
     encumbrance.ready.percentage = Math.clamp((encumbrance.ready.value * 100) / encumbrance.ready.max, 0, 100);
     encumbrance.stowed.percentage = Math.clamp((encumbrance.stowed.value * 100) / encumbrance.stowed.max, 0, 100);
 

--- a/module/data/actors/actor-character.mjs
+++ b/module/data/actors/actor-character.mjs
@@ -40,11 +40,6 @@ export default class SWNCharacter extends SWNActorBase {
     schema.employer = SWNShared.requiredString("");
     schema.biography = SWNShared.requiredString("");
     schema.languages = new fields.ArrayField(SWNShared.requiredString(""));
-    schema.credits = new fields.SchemaField({
-      debt: SWNShared.requiredNumber(0),
-      balance: SWNShared.requiredNumber(0),
-      owed: SWNShared.requiredNumber(0)
-    });
     schema.unspentSkillPoints = SWNShared.requiredNumber(0);
     schema.unspentPsySkillPoints = SWNShared.requiredNumber(0);
     schema.extra = SWNShared.resourceField(0, 10);

--- a/module/data/actors/base-actor.mjs
+++ b/module/data/actors/base-actor.mjs
@@ -33,6 +33,19 @@ export default class SWNActorBase extends foundry.abstract
       /* Values: array of { powerId, powerName, amount, duration } */
     });
 
+    schema.credits = new fields.SchemaField({
+      debt: SWNShared.requiredNumber(0), //deprecated
+      balance: SWNShared.requiredNumber(0), //deprecated
+      owed: SWNShared.requiredNumber(0), //deprecated
+      carriedBase: SWNShared.requiredNumber(0),
+      extraCurrencies: new fields.ArrayField(new fields.SchemaField({
+        name: SWNShared.requiredString(""),
+        type: SWNShared.stringChoices('base', CONFIG.SWN.currencyTypes),
+        value: new fields.NumberField({ required: true, nullable: false, integer: true, initial: 0 }),
+        carried: new fields.BooleanField({required: true, initial: true}),
+      }))
+    });
+
     schema.speed = SWNShared.requiredNumber(10);
     schema.cyberdecks = new fields.ArrayField(new fields.DocumentIdField()); 
     schema.health_max_modified = SWNShared.requiredNumber(0);
@@ -41,6 +54,14 @@ export default class SWNActorBase extends foundry.abstract
 
   prepareDerivedData() {
     this.health.percentage = Math.clamp((this.health.value * 100) / this.health.max, 0, 100);
+    for (let currency of this.credits.extraCurrencies) {
+      if (currency.type === 'base') {
+        currency.typeName = game.settings.get("swnr", "baseCurrencyName");
+      } else {
+        currency.typeName = game.settings.get("swnr", `customCurrencyName${currency.type}`);
+      }
+    }
+      
   }
 
   rollSave(_saveType) {

--- a/module/data/actors/base-actor.mjs
+++ b/module/data/actors/base-actor.mjs
@@ -37,7 +37,7 @@ export default class SWNActorBase extends foundry.abstract
       debt: SWNShared.requiredNumber(0), //deprecated
       balance: SWNShared.requiredNumber(0), //deprecated
       owed: SWNShared.requiredNumber(0), //deprecated
-      carriedBase: SWNShared.requiredNumber(0),
+      carriedBase: new fields.NumberField({ required: true, nullable: false, integer: true, initial: 0 }),
       extraCurrencies: new fields.ArrayField(new fields.SchemaField({
         name: SWNShared.requiredString(""),
         type: SWNShared.stringChoices('base', CONFIG.SWN.currencyTypes),

--- a/module/data/items/base-item.mjs
+++ b/module/data/items/base-item.mjs
@@ -10,7 +10,8 @@ export default class SWNItemBase extends foundry.abstract
     schema.favorite = new fields.BooleanField({initial: false});
     schema.modDesc = SWNShared.nullableString();
     schema.condition = SWNShared.stringChoices("perfect", CONFIG.SWN.gearCondition);
-
+    schema.gmNotes = SWNShared.nullableString();
+    schema.showGMNotes = new fields.BooleanField({initial: false});
     return schema;
   }
 }

--- a/module/data/items/item-weapon.mjs
+++ b/module/data/items/item-weapon.mjs
@@ -156,6 +156,8 @@ export default class SWNWeapon extends SWNBaseGearItem {
 
     let traumaRollRender = null;
     let traumaDamage = null;
+    let traumaRoll = null;
+    let traumaRating = null;
     let useTrauma = (game.settings.get("swnr", "useTrauma") ? true : false);
     let damageRoll = null;
 
@@ -173,7 +175,8 @@ export default class SWNWeapon extends SWNBaseGearItem {
       damage: null,
       damageFormula: damageRoll.formula,
       damageExplain: damageExplainTip,
-  };
+    };
+  
 
     // Roll Damage automatically if the setting is enabled
     const damageRollEnabled = game.settings.get("swnr", "damageRoll");
@@ -189,7 +192,7 @@ export default class SWNWeapon extends SWNBaseGearItem {
         this.trauma.die !== "none" &&
         this.trauma.rating != null
       ) {
-        const traumaRoll = new Roll(this.trauma.die);
+        traumaRoll = new Roll(this.trauma.die);
         await traumaRoll.roll();
         traumaRollRender = await traumaRoll.render();
         if (
@@ -206,7 +209,17 @@ export default class SWNWeapon extends SWNBaseGearItem {
         }
       }
     } // End of Damage Roll if setting is enabled
-
+    else {
+      if (
+        useTrauma &&
+        this.trauma.die != null &&
+        this.trauma.die !== "none" &&
+        this.trauma.rating != null
+      ) {
+        traumaRoll = new Roll(this.trauma.die);
+        traumaRating = this.trauma.rating;
+      }
+    } // end of no damage roll setting
     // Placeholder for shock damage
     let shock_content = null;
     let shock_roll = null;
@@ -278,8 +291,8 @@ export default class SWNWeapon extends SWNBaseGearItem {
             "actorId": actor.id,
             "flavor": `Damage roll for ${dialogData.weapon.name}`,
             "weaponId": this.id,
-            "traumaDamage": traumaDamage,
-            "traumaRollRender": traumaRollRender,
+            "traumaFormula": traumaRoll?.formula || null,
+            "traumaRating": traumaRating,
           },
         }
       };

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -28,6 +28,8 @@ SWN.maxPowerLevel = 10;
 
 SWN.maxSkillRank = 4;
 
+SWN.maxCustomCurrencyTypes = 5;
+
 SWN.itemLocations = {
   readied: 'swnr.item.locationReadied', 
   stowed: 'swnr.item.locationStowed', 

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -30,6 +30,14 @@ SWN.maxSkillRank = 4;
 
 SWN.maxCustomCurrencyTypes = 5;
 
+SWN.currencyTypes = {
+  base: 'base'
+};
+
+for (let i = 0; i < SWN.maxCustomCurrencyTypes; i++) {
+  SWN.currencyTypes[`${i}`] = `custom${i}`;
+}
+
 SWN.itemLocations = {
   readied: 'swnr.item.locationReadied', 
   stowed: 'swnr.item.locationStowed', 

--- a/module/helpers/register-settings.mjs
+++ b/module/helpers/register-settings.mjs
@@ -275,6 +275,35 @@ export const registerSettings = function () {
     // requiresReload: true,
   });
 
+
+  for (let i = 0; i < CONFIG.SWN.maxCustomCurrencyTypes; i++) {
+    game.settings.register("swnr", `customCurrencyName${i}`, {
+      name: `swnr.settings.currency.customName`,
+      hint: `swnr.settings.currency.customNameHint`,
+      scope: "world",
+      config: false, // restrict to menu
+      type: String,
+      default: "",
+    });
+
+    game.settings.register("swnr", `customCurrencyEnc${i}`, {
+      name: `swnr.settings.currency.customEnc`,
+      hint: `swnr.settings.currency.customEncHint`,
+      scope: "world",
+      config: false, // restrict to menu
+      type: Number,
+      default: 0,
+    });
+
+    game.settings.register("swnr", `customCurrencyConversionRate${i}`, {
+      name: `swnr.settings.currency.customConversionRate`,
+      hint: `swnr.settings.currency.customConversionRateHint`,
+      scope: "world",
+      config: false, // restrict to menu
+      type: Number,
+      default: 0,
+    });
+  }
   game.settings.registerMenu("swnr", "currencySettingsMenu", {
     name: "swnr.settings.currency.title",
     label: "swnr.settings.currency.title",      // The text label used in the button
@@ -314,6 +343,11 @@ export const getGameSettings = function () {
       baseCurrencyEnc: game.settings.get("swnr", "baseCurrencyEnc"),
     }
   };
+  for (let i = 0; i < CONFIG.SWN.maxCustomCurrencyTypes; i++) {
+    settings.currency[`customCurrencyName${i}`] = game.settings.get("swnr", `customCurrencyName${i}`);
+    settings.currency[`customCurrencyEnc${i}`] = game.settings.get("swnr", `customCurrencyEnc${i}`);
+    settings.currency[`customCurrencyConversionRate${i}`] = game.settings.get("swnr", `customCurrencyConversionRate${i}`);
+  }
   return settings;
 };
 
@@ -359,16 +393,33 @@ const { fields } = foundry.data;
 
 export class CurrencyFormModel extends foundry.abstract.DataModel {
   static defineSchema() {
-    return {
+    const schema = {
       baseCurrencyName: new fields.StringField({ label: "swnr.settings.currency.baseName", hint: "swnr.settings.currency.baseNameHint", required: true }),
       baseCurrencyEnc: new foundry.data.fields.NumberField({
         label: "swnr.settings.currency.baseEnc",
         hint: "swnr.settings.currency.baseEncHint",
         min: 0, max: 100, step: 1,
         initial: 0, nullable: false
-      })
-      // baseCurrencyEncWeight:  new fields.NumberField({ label: "swnr.settings.currency.baseEncWeight",   required: true }),// bonus: new fields.NumberField({ label: "Bonus",  integer: true, initial: 0 })
+      }),
+      // 5 custom currencies
+      customCurrencyName0: new fields.StringField({ label: `swnr.settings.currency.customName`, hint: `swnr.settings.currency.customNameHint`, required: false }),
+      customCurrencyEnc0: new foundry.data.fields.NumberField({ label: `swnr.settings.currency.customEnc`, hint: `swnr.settings.currency.customEncHint`, min: 0, max: 100, step: 1, initial: 0, nullable: false }),
+      customCurrencyConversionRate0: new foundry.data.fields.NumberField({ label: `swnr.settings.currency.customConversionRate`, hint: `swnr.settings.currency.customConversionRateHint`, min: -100, max: 100, step: 1, initial: 10, nullable: false }),
+      customCurrencyName1: new fields.StringField({ label: `swnr.settings.currency.customName`, hint: `swnr.settings.currency.customNameHint`, required: false }),
+      customCurrencyEnc1: new foundry.data.fields.NumberField({ label: `swnr.settings.currency.customEnc`, hint: `swnr.settings.currency.customEncHint`, min: 0, max: 100, step: 1, initial: 0, nullable: false }),
+      customCurrencyConversionRate1: new foundry.data.fields.NumberField({ label: `swnr.settings.currency.customConversionRate`, hint: `swnr.settings.currency.customConversionRateHint`, min: -100, max: 100, step: 1, initial: 10, nullable: false }),
+      customCurrencyName2: new fields.StringField({ label: `swnr.settings.currency.customName`, hint: `swnr.settings.currency.customNameHint`, required: false }),
+      customCurrencyEnc2: new foundry.data.fields.NumberField({ label: `swnr.settings.currency.customEnc`, hint: `swnr.settings.currency.customEncHint`, min: 0, max: 100, step: 1, initial: 0, nullable: false }),
+      customCurrencyConversionRate2: new foundry.data.fields.NumberField({ label: `swnr.settings.currency.customConversionRate`, hint: `swnr.settings.currency.customConversionRateHint`, min: -100, max: 100, step: 1, initial: 10, nullable: false }),
+      customCurrencyName3: new fields.StringField({ label: `swnr.settings.currency.customName`, hint: `swnr.settings.currency.customNameHint`, required: false }),
+      customCurrencyEnc3: new foundry.data.fields.NumberField({ label: `swnr.settings.currency.customEnc`, hint: `swnr.settings.currency.customEncHint`, min: 0, max: 100, step: 1, initial: 0, nullable: false }),
+      customCurrencyConversionRate3: new foundry.data.fields.NumberField({ label: `swnr.settings.currency.customConversionRate`, hint: `swnr.settings.currency.customConversionRateHint`, min: -100, max: 100, step: 1, initial: 10, nullable: false }),
+      customCurrencyName4: new fields.StringField({ label: `swnr.settings.currency.customName`, hint: `swnr.settings.currency.customNameHint`, required: false }),
+      customCurrencyEnc4: new foundry.data.fields.NumberField({ label: `swnr.settings.currency.customEnc`, hint: `swnr.settings.currency.customEncHint`, min: 0, max: 100, step: 1, initial: 0, nullable: false }),
+      customCurrencyConversionRate4: new foundry.data.fields.NumberField({ label: `swnr.settings.currency.customConversionRate`, hint: `swnr.settings.currency.customConversionRateHint`, min: -100, max: 100, step: 1, initial: 10, nullable: false }),
     };
+
+    return schema;
   }
 }
 
@@ -392,7 +443,7 @@ class CurrencySubmenuApplicationClass extends HandlebarsApplicationMixin(Applica
       contentClasses: ["standard-form"],
       title: "swnr.settings.currency.title"
     },
-    classes: ['swnr', 'currency-settings'],
+    classes: ['swnr', 'settings-form', 'currency-settings'],
 
   }
 
@@ -411,8 +462,19 @@ class CurrencySubmenuApplicationClass extends HandlebarsApplicationMixin(Applica
   }
 
   _onRender(context, options) {
-    // this.element.querySelector("input[name=something]").addEventListener("click", /* ... */);
-    // We will deal with reset later
+    super._onRender(context, options);
+    this.element.querySelector("select[name=loadPreset]").addEventListener("change", this._onLoadPresetChange.bind(this));
+  }
+  async _onLoadPresetChange(event) {
+    event.preventDefault();
+    const value = event.target.value;
+    if (value === "none") {
+      return;
+    }
+    ui.notifications.info(`Loading preset: ${value}`);
+    //TODO 
+    // - Set the base currency name and encumbrance
+
   }
 
   async _prepareContext(options) {

--- a/module/helpers/register-settings.mjs
+++ b/module/helpers/register-settings.mjs
@@ -501,7 +501,7 @@ class CurrencySubmenuApplicationClass extends HandlebarsApplicationMixin(Applica
     if (event.type === "submit") {
       const settings = foundry.utils.expandObject(formData.object);
       for (const [key, value] of Object.entries(settings)) {
-        if (key !== "submit" && key !== "cancel") {
+        if (key !== "submit" && key !== "cancel" && key !== "loadPreset") {
           await game.settings.set("swnr", key, value);
         }
       }

--- a/module/helpers/register-settings.mjs
+++ b/module/helpers/register-settings.mjs
@@ -471,10 +471,78 @@ class CurrencySubmenuApplicationClass extends HandlebarsApplicationMixin(Applica
     if (value === "none") {
       return;
     }
-    ui.notifications.info(`Loading preset: ${value}`);
-    //TODO 
+    const confirmed = await Dialog.confirm({
+      title: "Confirm Delete",
+      content: `<p>Are you sure you want to load presets for currency? Existing currency settings will be overwritten and there is no undo.</p>`,
+      yes: () => true,
+      no: () => false,
+      defaultYes: false
+    });
+    if (!confirmed) {
+      event.target.value = "none";
+      return;
+    }
     // - Set the base currency name and encumbrance
-
+    if (value === "swn") {
+      game.settings.set("swnr", "baseCurrencyName", "Credits");
+      game.settings.set("swnr", "baseCurrencyEnc", 0);
+      game.settings.set("swnr", "customCurrencyName0", "");
+      game.settings.set("swnr", "customCurrencyName1", "");
+      game.settings.set("swnr", "customCurrencyName2", "");
+      game.settings.set("swnr", "customCurrencyName3", "");
+      game.settings.set("swnr", "customCurrencyName4", "");
+    } else if (value === "cwn") {
+      game.settings.set("swnr", "baseCurrencyName", "Dollars");
+      game.settings.set("swnr", "baseCurrencyEnc", 0);
+      game.settings.set("swnr", "customCurrencyName0", "");
+      game.settings.set("swnr", "customCurrencyName1", "");
+      game.settings.set("swnr", "customCurrencyName2", "");
+      game.settings.set("swnr", "customCurrencyName3", "");
+      game.settings.set("swnr", "customCurrencyName4", "");
+    } else if (value === "awn") {
+      game.settings.set("swnr", "baseCurrencyName", "Gold Escudo");
+      game.settings.set("swnr", "baseCurrencyEnc", 100);
+      game.settings.set("swnr", "customCurrencyName0", "Silver Peso");
+      game.settings.set("swnr", "customCurrencyEnc0", 100);
+      game.settings.set("swnr", "customCurrencyConversionRate0", 10);
+      game.settings.set("swnr", "customCurrencyName1", "Mandate Credit");
+      game.settings.set("swnr", "customCurrencyEnc1", 100);
+      game.settings.set("swnr", "customCurrencyConversionRate1", 10);
+      game.settings.set("swnr", "customCurrencyName2", "Ration");
+      game.settings.set("swnr", "customCurrencyEnc2", 1);
+      game.settings.set("swnr", "customCurrencyConversionRate2", 10);
+      game.settings.set("swnr", "customCurrencyName3", "");
+      game.settings.set("swnr", "customCurrencyName4", "");
+    } else if (value === "wwn") {
+      game.settings.set("swnr", "baseCurrencyName", "Silver");
+      game.settings.set("swnr", "baseCurrencyEnc", 100);
+      game.settings.set("swnr", "customCurrencyName0", "Gold");
+      game.settings.set("swnr", "customCurrencyEnc0", 100);
+      game.settings.set("swnr", "customCurrencyConversionRate0", -10);
+      game.settings.set("swnr", "customCurrencyName1", "Copper");
+      game.settings.set("swnr", "customCurrencyEnc1", 100);
+      game.settings.set("swnr", "customCurrencyConversionRate1", 0);
+      game.settings.set("swnr", "customCurrencyName2", "");
+      game.settings.set("swnr", "customCurrencyName3", "");
+      game.settings.set("swnr", "customCurrencyName4", "");
+    } else if (value === "ose") {
+      game.settings.set("swnr", "baseCurrencyName", "Gold");
+      game.settings.set("swnr", "baseCurrencyEnc", 100);
+      game.settings.set("swnr", "customCurrencyName0", "Silver");
+      game.settings.set("swnr", "customCurrencyEnc0", 100);
+      game.settings.set("swnr", "customCurrencyConversionRate0", 10);
+      game.settings.set("swnr", "customCurrencyName1", "Copper");
+      game.settings.set("swnr", "customCurrencyEnc1", 100);
+      game.settings.set("swnr", "customCurrencyConversionRate1", 100);
+      game.settings.set("swnr", "customCurrencyName2", "Platinum");
+      game.settings.set("swnr", "customCurrencyEnc2", 100);
+      game.settings.set("swnr", "customCurrencyConversionRate2", -5);
+      game.settings.set("swnr", "customCurrencyName3", "Electrum");
+      game.settings.set("swnr", "customCurrencyEnc3", 100);
+      game.settings.set("swnr", "customCurrencyConversionRate3", 2);
+      game.settings.set("swnr", "customCurrencyName4", "");
+    }
+    foundry.utils.debouncedReload();        
   }
 
   async _prepareContext(options) {

--- a/module/helpers/register-settings.mjs
+++ b/module/helpers/register-settings.mjs
@@ -113,6 +113,15 @@ export const registerSettings = function () {
     default: "d20", // The default value for the setting
   });
 
+  game.settings.register("swnr", "damageRoll", {
+    name: "swnr.settings.damageRoll",
+    hint: "swnr.settings.damageRollHint",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true,
+  });
+
   //CWN Settings
   game.settings.register("swnr", "useTrauma", {
     name: "swnr.settings.useTrauma",
@@ -326,6 +335,7 @@ export const getGameSettings = function () {
     //showTempAttrMod: game.settings.get("swnr", "showTempAttrMod"),
     attrRoll: game.settings.get("swnr", "attrRoll"),
     attackRoll: game.settings.get("swnr", "attackRoll"),
+    damageRoll: game.settings.get("swnr", "damageRoll"),
     useTrauma: game.settings.get("swnr", "useTrauma"),
     useCWNArmor: game.settings.get("swnr", "useCWNArmor"),
     useCWNCyber: game.settings.get("swnr", "useCWNCyber"),

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -474,21 +474,21 @@ const migrations = {
   "2.3.0": async () => {
     console.log('Running migration for 2.3.0');
     for (const actor of game.actors) {
-      let newCurrencies = [];
+      let newCurrencies = actor.system.credits.extraCurrencies ? actor.system.credits.extraCurrencies : [];
       if (actor.type === 'character' ) {
-        if (actor.system.currency.debt > 0) {
+        if (actor.system.credits?.debt && actor.system.credits.debt > 0) {
           newCurrencies.push({
             name: actor.system.tweak.debtDisplay || "Debt",
             type: 'base',
-            value: actor.system.currency.debt,
+            value: actor.system.credits.debt,
             carried: true
           });
         }
-        if (actor.system.currency.owed > 0) {
+        if (actor.system.credits?.owed && actor.system.credits.owed > 0) {
           newCurrencies.push({
             name: actor.system.tweak.owedDisplay || "Owed",
             type: 'base',
-            value: actor.system.currency.owed,
+            value: actor.system.credits.owed,
             carried: true
           });
         }

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -470,6 +470,35 @@ const migrations = {
       ui.notifications?.error(`Migration 2.1.0 failed: ${err.message}. Check console for details.`);
       throw err;
     }
+  },
+  "2.3.0": async () => {
+    console.log('Running migration for 2.3.0');
+    for (const actor of game.actors) {
+      let newCurrencies = [];
+      if (actor.type === 'character' ) {
+        if (actor.system.currency.debt > 0) {
+          newCurrencies.push({
+            name: actor.system.tweak.debtDisplay || "Debt",
+            type: 'base',
+            value: actor.system.currency.debt,
+            carried: true
+          });
+        }
+        if (actor.system.currency.owed > 0) {
+          newCurrencies.push({
+            name: actor.system.tweak.owedDisplay || "Owed",
+            type: 'base',
+            value: actor.system.currency.owed,
+            carried: true
+          });
+        }
+        await actor.update({
+          "system.credits.extraCurrencies": newCurrencies,
+          "system.credits.carriedBase": actor.system.credits.balance,
+        });
+        ui.notifications?.info(`Migrated ${actor.name} to 2.3.0`);
+      }
+    }
   }
 };
 

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -64,6 +64,7 @@ export class SWNActorSheet extends SWNBaseSheet {
       removeLanguage: this._onRemoveLanguage,
       toggleLanguageAdd: this._onToggleLanguageAdd,
       stressRoll: this._onStressRoll,
+      modStress: this._onModStress,
     },
     // Custom property that's merged into `this.options`
     dragDrop: [{ dragSelector: '[data-drag]', dropSelector: null }],
@@ -1565,6 +1566,14 @@ export class SWNActorSheet extends SWNBaseSheet {
       return;
     }
     this.actor.system.rollStress();
+  }
+
+  static async _onModStress(event, _target) {
+    event.preventDefault();
+    if (this.actor.type !== "character") {
+      return;
+    }
+    this.actor.system.modStress();
   }
 
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -63,6 +63,7 @@ export class SWNActorSheet extends SWNBaseSheet {
       addLanguage: this._onAddLanguage,
       removeLanguage: this._onRemoveLanguage,
       toggleLanguageAdd: this._onToggleLanguageAdd,
+      stressRoll: this._onStressRoll,
     },
     // Custom property that's merged into `this.options`
     dragDrop: [{ dragSelector: '[data-drag]', dropSelector: null }],
@@ -1556,6 +1557,14 @@ export class SWNActorSheet extends SWNBaseSheet {
         }
       }
     }
+  }
+
+  static async _onStressRoll(event, _target) {
+    event.preventDefault();
+    if (this.actor.type !== "character") {
+      return;
+    }
+    this.actor.system.rollStress();
   }
 
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -38,6 +38,8 @@ export class SWNActorSheet extends SWNBaseSheet {
       roll: this._onRoll,
       reload: this._onReload,
       creditChange: this._onCreditChange,
+      addCurrency: this._onAddCurrency,
+      editCurrency: this._onEditCurrency,
       addUse: this._onAddUse,
       removeUse: this._onRemoveUse,
       rest: this._onRest,
@@ -1235,6 +1237,129 @@ export class SWNActorSheet extends SWNBaseSheet {
       console.error("Error handling power preparation:", error);
       ui.notifications?.error("An error occurred while changing power preparation");
     }
+  }
+
+  static async _onEditCurrency(event, target) {
+    event.preventDefault();
+    const currencyIdx = target.dataset.currencyIdx;
+    const currency = this.actor.system.credits.extraCurrencies[currencyIdx];
+    const template = "systems/swnr/templates/dialogs/add-currency-type.hbs";
+    const content = await renderTemplate(template, { settings: getGameSettings(), currency: currency });
+    const _resp = await foundry.applications.api.DialogV2.wait(
+      {
+        window: {
+          title: game.i18n.format("swnr.sheet.editCurrency",
+            { actor: this.actor.name }
+          )
+        },
+        content,
+        modal: false,
+        rejectClose: false,
+        buttons: [
+        {
+          label: game.i18n.localize("swnr.sheet.editCurrency"),
+          action: "edit",
+          icon: 'fas fa-edit',
+          callback: async (_event, button, _dialog) => {
+            const currencyType = button.form.elements.currencyType.value;
+            const currencyName = button.form.elements.currencyName.value;
+            const currencyValue = button.form.elements.currencyValue.value;
+            const carried = button.form.elements.carried.checked;
+            const currency = {
+              type: currencyType,
+              name: currencyName,
+              value: currencyValue,
+              carried: carried,
+            };
+            const currencyList = duplicate(this.actor.system.credits.extraCurrencies);
+            currencyList[currencyIdx] = currency;
+            await this.actor.update({
+              "system.credits.extraCurrencies": currencyList
+            });
+            return "edit";
+          }
+        }, 
+        {
+          label: game.i18n.localize("swnr.sheet.deleteCurrency"),
+          action: "delete",
+          icon: 'fas fa-trash',
+          callback: async (_event, _button, _dialog) => {
+            // confirm deletion
+            const confirmed = await Dialog.confirm({
+              title: "Confirm Delete",
+              content: `<p>Are you sure you want to delete this currency? The value will be lost and there is no undo.</p>`,
+              yes: () => true,
+              no: () => false,
+              defaultYes: false
+            });
+        
+            if (!confirmed) {
+              ui.notifications.info("Currency deletion cancelled");
+              return "cancel";
+            }
+            const currencyList = duplicate(this.actor.system.credits.extraCurrencies);
+            currencyList.splice(currencyIdx, 1);
+            await this.actor.update({
+              "system.credits.extraCurrencies": currencyList
+            });
+            return "delete";
+          }
+        }, {
+          label: game.i18n.localize("swnr.sheet.convertToBaseCurrency"),
+          action: "convert",
+          icon: 'fas fa-exchange-alt',
+          callback: async (_event, _button, _dialog) => {
+            const currency = this.actor.system.credits.extraCurrencies[currencyIdx];
+            ui.notifications?.info(`Converting ${currency.name} to base currency`);
+            return "convert";
+            // currency.type = "base";
+            // await this.actor.update({
+            //   "system.credits.extraCurrencies": [...this.actor.system.credits.extraCurrencies, currency]
+            // });
+          }
+        }
+      ]
+      }
+    );
+  }
+
+  static async _onAddCurrency(event, target) {
+    event.preventDefault();
+    const template = "systems/swnr/templates/dialogs/add-currency-type.hbs";
+    const content = await renderTemplate(template, { settings: getGameSettings(), currency: {} });
+
+    const _resp = await foundry.applications.api.DialogV2.prompt(
+      {
+        window: {
+          title: game.i18n.format("swnr.sheet.addCurrency",
+            { actor: this.actor.name }
+          )
+        },
+        content,
+        modal: true,
+        rejectClose: false,
+        ok:
+        {
+          label: game.i18n.localize("swnr.sheet.addCurrency"),
+          callback: async (event, button, dialog) => {
+            const currencyType = button.form.elements.currencyType.value;
+            const currencyName = button.form.elements.currencyName.value;
+            const currencyValue = button.form.elements.currencyValue.value;
+            const carried = button.form.elements.carried.checked;
+            const currency = {
+              type: currencyType,
+              name: currencyName,
+              value: currencyValue,
+              carried: carried,
+            };
+            await this.actor.update({
+              "system.credits.extraCurrencies": [...this.actor.system.credits.extraCurrencies, currency]
+            });
+          }
+        },
+      }
+    );
+
   }
 
   static async _onAddUse(event, target) {

--- a/module/sheets/base-sheet.mjs
+++ b/module/sheets/base-sheet.mjs
@@ -53,6 +53,32 @@ export class SWNBaseSheet extends api.HandlebarsApplicationMixin(
         }
       }
     }
+    // Toggle show power type on features tab
+    if (this.actor.type === "character" && (item.type === "power" || item.type === "cyberware")) {
+      const mapping = {
+        "psychic": "showPsychic",
+        "art": "showArts",
+        "adept": "showAdept",
+        "spell": "showSpells",
+        "mutation": "showMutation",
+        "cyberware": "showCyberware"
+      }
+      let propertyToUpdate = null;
+      if (mapping[item.system.subType]) {
+        propertyToUpdate = mapping[item.system.subType];
+      } else if (item.type === "cyberware") {
+        propertyToUpdate = mapping[item.type];
+      }
+      if (propertyToUpdate) {
+        await this.actor.update({
+          "system": {
+            "tweak": {
+              [propertyToUpdate]: true
+            }
+          }
+        });
+      }
+    }
 
     // Create the owned item
     return this._onDropItemCreate(item, event);

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -228,6 +228,7 @@ export class SWNItemSheet extends api.HandlebarsApplicationMixin(
       editable: this.isEditable,
       owner: this.document.isOwner,
       limited: this.document.limited,
+      isGM: game.user.isGM,
       // Add the item document.
       item: this.item,
       // Adding system and flags for easier access

--- a/module/sheets/vehicle-sheet.mjs
+++ b/module/sheets/vehicle-sheet.mjs
@@ -1301,7 +1301,7 @@ export class SWNVehicleSheet extends SWNBaseSheet {
     );
   }
 
-  static async _setCaptSupport(dept) {
+  async _setCaptSupport(dept) {
     const deptSupport = this.actor.system.supportingDept
       ? this.actor.system.supportingDept
       : "";

--- a/src/scss/components/_chat.scss
+++ b/src/scss/components/_chat.scss
@@ -24,6 +24,13 @@
     margin-top: 4px;
   }
 
+  .flex-center {
+    display: flex;
+    justify-content: center; /* centers horizontally */
+    align-items: center;      /* centers vertically (optional) */
+    margin-top: 0.5em;        /* optional spacing */
+  }
+
   // Power Usage Chat Cards
   .power-usage {
     .resource-cost {

--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -15,6 +15,30 @@
   gap: 4px;
 }
 
+.settings-form {
+  overflow-y: auto;    /* vertical scrollbar */
+  overflow-x: hidden;  /* optional */
+  padding-right: 0.5em; /* space for scrollbar */
+
+  .custom-currency-container {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    border: 1px solid var(--border-color);
+    border-radius: 2px;
+    padding: 4px;
+    margin: 4px;
+    
+    .h4 {
+      margin-bottom: 1rem;
+    }
+  }
+
+  .h4 {
+    margin-bottom: 1rem;
+  }
+}
+
 .sheet-header {
   flex: 0 auto;
   /* overflow: hidden; TODO */

--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -50,6 +50,7 @@
     user-select: text;
     transition: outline-color 0.5s;
     min-width: 20px;
+    box-shadow: none;
   }
 
   select {

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "swnr",
   "title": "Systems Without Number (Stars, Cities, Worlds, and Ashes)",
   "description": "The Stars, Cities, Worlds, and Ashes Without Number System for FoundryVTT!",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "authors": [
     {
       "name": "wintersleepAI",

--- a/templates/actor/effects.hbs
+++ b/templates/actor/effects.hbs
@@ -17,7 +17,7 @@
         <div class='effect-source'>
           {{localize 'SWN.Effect.Source'}}
         </div>
-        <div class='effect-source'>{{localize 'EFFECT.TabDuration'}}</div>
+        <div class='effect-source'>{{localize 'Effect.TabDuration'}}</div>
         <div class='effect-controls flexrow'>
           <a
             class='effect-control'

--- a/templates/actor/features.hbs
+++ b/templates/actor/features.hbs
@@ -243,26 +243,23 @@
 
               <!-- Deprecated Currency Fields-->
               <div class="flex flex-col items-center">
+                <label for="system.credits.debt">{{system.tweak.debtDisplay}} (deprecated)
+                </label>
                 {{formInput systemFields.credits.fields.debt value=system.credits.debt localize=true readonly=true}}
-                <label for="system.credits.debt">{{system.tweak.debtDisplay}}
-                {{!-- <a class="credits-change text-gray-100 hover:text-green-400 transition-colors"
-                  title="{{localize 'swnr.sheet.credit-change'}} {{system.tweak.debtDisplay}}"
-                  data-credit-type="debt" data-action="creditChange">
-                    <i class="fas fa-coins"></i> --}}
-                </a> 
-                </label>
-              </div>
-              <div class="flex flex-col items-center">
-                {{formInput systemFields.credits.fields.balance value=system.credits.balance localize=true}}
-                <label for="system.credits.balance">{{system.tweak.balanceDisplay}}
 
-                </label>
               </div>
               <div class="flex flex-col items-center">
-                {{formInput systemFields.credits.fields.owed value=system.credits.owed localize=true}}
-                <label for="system.credits.owed">{{system.tweak.owedDisplay}}
+                <label for="system.credits.balance">{{system.tweak.balanceDisplay}} (deprecated)
                 </label>
+                {{formInput systemFields.credits.fields.balance value=system.credits.balance localize=true readonly=true}}
+
               </div>
+              <div class="flex flex-col items-center">
+                <label for="system.credits.owed">{{system.tweak.owedDisplay}} (deprecated)
+                </label>
+                {{formInput systemFields.credits.fields.owed value=system.credits.owed localize=true readonly=true}}
+              </div>
+              {{!-- End Deprecated Currency Fields --}}
 
               {{formGroup systemFields.tweak.fields.showCyberware value=system.tweak.showCyberware localize=true}}
               {{formGroup systemFields.tweak.fields.showPsychic value=system.tweak.showPsychic localize=true}}

--- a/templates/actor/features.hbs
+++ b/templates/actor/features.hbs
@@ -235,11 +235,35 @@
             <div class="grid grid-col2"> <!-- Character Tweak options -->
               {{formGroup systemFields.tweak.fields.advInit value=system.tweak.advInit localize=true}}
               {{formGroup systemFields.tweak.fields.initiative.fields.mod value=system.tweak.initiative.mod localize=true}}
-              {{formGroup systemFields.tweak.fields.debtDisplay value=system.tweak.debtDisplay localize=true}}
+              {{!-- DEPRECATED {{formGroup systemFields.tweak.fields.debtDisplay value=system.tweak.debtDisplay localize=true}}
               {{formGroup systemFields.tweak.fields.balanceDisplay value=system.tweak.balanceDisplay localize=true}}
-              {{formGroup systemFields.tweak.fields.owedDisplay value=system.tweak.owedDisplay localize=true}}     
+              {{formGroup systemFields.tweak.fields.owedDisplay value=system.tweak.owedDisplay localize=true}}      --}}
               {{formGroup systemFields.tweak.fields.modifiers.fields.readied value=system.tweak.modifiers.readied localize=true}}
               {{formGroup systemFields.tweak.fields.modifiers.fields.stowed value=system.tweak.modifiers.stowed localize=true}}
+
+              <!-- Deprecated Currency Fields-->
+              <div class="flex flex-col items-center">
+                {{formInput systemFields.credits.fields.debt value=system.credits.debt localize=true readonly=true}}
+                <label for="system.credits.debt">{{system.tweak.debtDisplay}}
+                {{!-- <a class="credits-change text-gray-100 hover:text-green-400 transition-colors"
+                  title="{{localize 'swnr.sheet.credit-change'}} {{system.tweak.debtDisplay}}"
+                  data-credit-type="debt" data-action="creditChange">
+                    <i class="fas fa-coins"></i> --}}
+                </a> 
+                </label>
+              </div>
+              <div class="flex flex-col items-center">
+                {{formInput systemFields.credits.fields.balance value=system.credits.balance localize=true}}
+                <label for="system.credits.balance">{{system.tweak.balanceDisplay}}
+
+                </label>
+              </div>
+              <div class="flex flex-col items-center">
+                {{formInput systemFields.credits.fields.owed value=system.credits.owed localize=true}}
+                <label for="system.credits.owed">{{system.tweak.owedDisplay}}
+                </label>
+              </div>
+
               {{formGroup systemFields.tweak.fields.showCyberware value=system.tweak.showCyberware localize=true}}
               {{formGroup systemFields.tweak.fields.showPsychic value=system.tweak.showPsychic localize=true}}
               {{formGroup systemFields.tweak.fields.showArts value=system.tweak.showArts localize=true}}

--- a/templates/actor/features.hbs
+++ b/templates/actor/features.hbs
@@ -237,7 +237,9 @@
               {{formGroup systemFields.tweak.fields.initiative.fields.mod value=system.tweak.initiative.mod localize=true}}
               {{formGroup systemFields.tweak.fields.debtDisplay value=system.tweak.debtDisplay localize=true}}
               {{formGroup systemFields.tweak.fields.balanceDisplay value=system.tweak.balanceDisplay localize=true}}
-              {{formGroup systemFields.tweak.fields.owedDisplay value=system.tweak.owedDisplay localize=true}}            
+              {{formGroup systemFields.tweak.fields.owedDisplay value=system.tweak.owedDisplay localize=true}}     
+              {{formGroup systemFields.tweak.fields.modifiers.fields.readied value=system.tweak.modifiers.readied localize=true}}
+              {{formGroup systemFields.tweak.fields.modifiers.fields.stowed value=system.tweak.modifiers.stowed localize=true}}
               {{formGroup systemFields.tweak.fields.showCyberware value=system.tweak.showCyberware localize=true}}
               {{formGroup systemFields.tweak.fields.showPsychic value=system.tweak.showPsychic localize=true}}
               {{formGroup systemFields.tweak.fields.showArts value=system.tweak.showArts localize=true}}

--- a/templates/actor/gear.hbs
+++ b/templates/actor/gear.hbs
@@ -1,38 +1,53 @@
 {{! Gear Tab }}
 <section class='tab gear sheet-body {{tab.cssClass}}' data-group='primary' data-tab='gear'>
   {{#if (eq actor.type 'character')}}
-  <div class="flex flexrow gap" style="column-gap:10%">
-    <div class="flex flex-col items-center">
-      {{formInput systemFields.credits.fields.debt value=system.credits.debt localize=true}}
-      <label for="system.credits.debt">{{system.tweak.debtDisplay}}
-      <a class="credits-change text-gray-100 hover:text-green-400 transition-colors"
-        title="{{localize 'swnr.sheet.credit-change'}} {{system.tweak.debtDisplay}}"
-        data-credit-type="debt" data-action="creditChange">
-          <i class="fas fa-coins"></i>
-      </a> 
+  <div class="grid grid-5col" style="column-gap:10px">
+    <div class="flex items-center">
+      {{formInput systemFields.credits.fields.carriedBase value=system.credits.carriedBase localize=true}}
+      <label for="system.credits.carriedBase">
+        <a class="credits-change text-gray-100 hover:text-green-400 transition-colors"
+          title="{{localize 'swnr.sheet.credit-change'}}  {{gameSettings.currency.baseCurrencyName}}"
+          data-credit-type="base" data-action="creditChange">
+            <i class="fas fa-coins"></i>
+          {{gameSettings.currency.baseCurrencyName}}
+        </a>
       </label>
     </div>
-    <div class="flex flex-col items-center">
-      {{formInput systemFields.credits.fields.balance value=system.credits.balance localize=true}}
-      <label for="system.credits.balance">{{system.tweak.balanceDisplay}}
-      <a class="credits-change text-gray-100 hover:text-green-400 transition-colors"
-        title="{{localize 'swnr.sheet.credit-change'}} {{system.tweak.balanceDisplay}}"
-        data-credit-type="balance" data-action="creditChange">
-          <i class="fas fa-coins"></i>
-      </a> 
-      </label>
+    {{#each actor.system.credits.extraCurrencies as |currency idx|}}
+      <div class="flex items-center">
+        <input type="number" name="currencyValue" value="{{currency.value}}" />
+        <a class="credits-change text-gray-100 hover:text-green-400 transition-colors"
+          title="{{localize 'swnr.sheet.credit-change'}}  {{currency.typeName}}"
+          data-credit-type="base" data-action="creditChange">
+            <i class="fas fa-coins"></i>
+        <label for="currencyValue">
+          {{#if currency.name}}
+           {{currency.name}} 
+           {{#if (ne currency.type 'base')}}
+             ({{currency.typeName}})
+           {{/if}}
+          {{else}}
+           {{currency.typeName}}
+          {{/if}}
+          </label>
+
+        <a class="currency-button" data-action="editCurrency" data-currency-idx="{{idx}}">
+          <i class="fas fa-edit"></i>
+        </a>
+      </div>
+    {{/each}}
+    <div>
+      <div class="currency-button flex flexcol items-center" data-tooltip="{{localize 'swnr.sheet.addCurrencyHint'}}">
+        <a data-action="addCurrency"><i class="fas fa-money-bill-wave fa-2x"></i></a>
+        {{localize 'swnr.sheet.addCurrency'}}
+      </div>
     </div>
-    <div class="flex flex-col items-center">
-      {{formInput systemFields.credits.fields.owed value=system.credits.owed localize=true}}
-      <label for="system.credits.owed">{{system.tweak.owedDisplay}}
-      <a class="credits-change text-gray-100 hover:text-green-400 transition-colors"
-        title="{{localize 'swnr.sheet.credit-change'}} {{system.tweak.owedDisplay}}"
-        data-credit-type="owed" data-action="creditChange">
-          <i class="fas fa-coins"></i>
-      </a>
-      </label>
-    </div>
+    {{!-- <div>
+      {{formInput systemFields.credits.fields.extraCurrencies value=system.credits.extraCurrencies localize=true}}
+      <label for="system.credits.extraCurrencies">Extra Currencies</label>
+    </div> --}}
   </div>
+
 
   <div class="flex flexrow gap" style="column-gap:10%;"><!-- Encum -->
 

--- a/templates/actor/gear.hbs
+++ b/templates/actor/gear.hbs
@@ -15,7 +15,7 @@
     </div>
     {{#each actor.system.credits.extraCurrencies as |currency idx|}}
       <div class="flex items-center">
-        <input type="number" name="currencyValue" value="{{currency.value}}" />
+        <input type="number" name="currencyValue" value="{{currency.value}}" readonly />
         <a class="credits-change text-gray-100 hover:text-green-400 transition-colors"
           title="{{localize 'swnr.sheet.credit-change'}}  {{currency.typeName}}"
           data-credit-type="base" data-action="creditChange">

--- a/templates/actor/gear.hbs
+++ b/templates/actor/gear.hbs
@@ -7,9 +7,9 @@
       <label for="system.credits.carriedBase">
         <a class="credits-change text-gray-100 hover:text-green-400 transition-colors"
           title="{{localize 'swnr.sheet.credit-change'}}  {{gameSettings.currency.baseCurrencyName}}"
-          data-credit-type="base" data-action="creditChange">
+          data-credit-type=" {{gameSettings.currency.baseCurrencyName}}" data-currency-type="base" data-action="creditChange">
             <i class="fas fa-coins"></i>
-          {{gameSettings.currency.baseCurrencyName}}
+          {{gameSettings.currency.baseCurrencyName}} ({{localize 'swnr.item.locationStowed'}})
         </a>
       </label>
     </div>
@@ -18,7 +18,8 @@
         <input type="number" name="currencyValue" value="{{currency.value}}" readonly />
         <a class="credits-change text-gray-100 hover:text-green-400 transition-colors"
           title="{{localize 'swnr.sheet.credit-change'}}  {{currency.typeName}}"
-          data-credit-type="base" data-action="creditChange">
+          data-credit-type="{{currency.typeName}}" data-currency-type="custom" 
+           data-currency-idx="{{idx}}" data-action="creditChange">
             <i class="fas fa-coins"></i>
         <label for="currencyValue">
           {{#if currency.name}}

--- a/templates/actor/header.hbs
+++ b/templates/actor/header.hbs
@@ -206,13 +206,23 @@
         {{formGroup systemFields.access value=system.access localize=true widget=headerWidget readonly=1}}
       {{/if}}
       
-      {{#if (eq actor.type 'character')}}
+      {{#if (eq actor.type 'character')}} <!-- Stress -->
         {{#if (eq gameSettings.useStress true)}}
-          {{formGroup systemFields.stress value=system.stress localize=true widget=headerWidget}}
+        <div class="resource flex-group-center">
+          <div class="resource-content">  
+            <div class="flex flexrow">
+              {{formInput systemFields.stress value=system.stress localize=true widget=headerWidget}}
+            </div> 
+          </div>
+          <label class='resource-label'>
+            <a data-action="stressRoll">
+              {{localize 'SWN.Actor.Character.FIELDS.stress.label'}}          
+              <i class="fa fa-dice-d20"></i>
+            </a>
+          </label>  
+        </div>
         {{/if}}
       {{/if}}
-
-
 
       {{#if (eq actor.type 'character')}}
       

--- a/templates/actor/header.hbs
+++ b/templates/actor/header.hbs
@@ -209,16 +209,34 @@
       {{#if (eq actor.type 'character')}} <!-- Stress -->
         {{#if (eq gameSettings.useStress true)}}
         <div class="resource flex-group-center">
-          <div class="resource-content">  
-            <div class="flex flexrow">
-              {{formInput systemFields.stress value=system.stress localize=true widget=headerWidget}}
-            </div> 
+          <div class="field resource-content">  
+              <input
+                type='text'
+                name='system.stress'
+                value='{{system.stress}}'
+                data-dtype='Number'
+                class='nested-field header'
+              />
+              <span class="nested-sep">(</span>
+              <input
+                type='text'
+                name='system.breakdowns'
+                value='{{system.breakdowns}}'
+                data-dtype='Number'
+                class='nested-field header'
+              />
+              <span class="nested-sep">)</span>
+
           </div>
-          <label class='resource-label'>
-            <a data-action="stressRoll">
+          <label class='resource-label' data-tooltip="{{localize 'swnr.sheet.stressLong'}}">
+            <a data-action="modStress" style="margin-right: 2px;">
               {{localize 'SWN.Actor.Character.FIELDS.stress.label'}}          
+              <i class="fas fa-plus-minus"></i>
+            </a>
+            <a data-action="stressRoll">
               <i class="fa fa-dice-d20"></i>
             </a>
+
           </label>  
         </div>
         {{/if}}

--- a/templates/actor/vehicle/ship.hbs
+++ b/templates/actor/vehicle/ship.hbs
@@ -27,7 +27,7 @@
       <div class="resource form-group flex flex-col">
         <div>
           <label>{{localize 'SWN.Actor.Ship.FIELDS.creditPool.label'}}</label>
-          <a class="credits-change" title="{{localize 'swnr.sheet.credit-change'}}" data-credit-type="creditPool">
+          <a class="credits-change" title="{{localize 'swnr.sheet.credit-change'}}" data-credit-type="creditPool" data-action="creditChange">
             <i class="fas fa-coins"></i> </a>
         </div>
         {{formInput systemFields.creditPool value=system.creditPool localize=true}}
@@ -37,8 +37,9 @@
         <div class="flex flex-col items-center">
           <div><a class="calc-cost" data-action="calcCost" title="{{localize 'swnr.sheet.ship.calc-cost'}}"><i
                 class=" fas fa-2x fa-cash-register"></i></a></div>
-          <div data-tooltip="{{localize 'swnr.sheet.ship.calc-cost-hint'}}"><label>{{localize
-              'swnr.sheet.ship.calc-cost'}}</label></div>
+          <div data-tooltip="{{localize 'swnr.sheet.ship.calc-cost-hint'}}">
+            <label>{{localize 'swnr.sheet.ship.calc-cost'}}</label>
+          </div>
         </div>
       </div>
 

--- a/templates/chat/attack-roll.hbs
+++ b/templates/chat/attack-roll.hbs
@@ -46,7 +46,7 @@
   {{/if}}
 
   {{#if weapon.system.save}}
-  <div class="card-buttons">
+  <div class="card-buttons flex-center">
       <button data-action="save" data-save="{{weapon.system.save}}">
           Save {{weapon.system.save}}
       </button>

--- a/templates/chat/damage-roll.hbs
+++ b/templates/chat/damage-roll.hbs
@@ -1,30 +1,8 @@
 <div class="chat-card item-card" data-actor-id="{{actor._id}}" data-item-id="{{weapon._id}}">
-  <h4 title="{{ weapon.system.description }}">{{ weapon.name }}</h4>
 
-  <span>To Hit:</span>
-  <span title="{{ diceTooltip.hitExplain }}" class="roll roll-hit">{{{ diceTooltip.hit }}}</span>
-  
-  {{# if diceTooltip.damage}}
   <span>{{localize 'swnr.weapon.damage'}}:</span>
-  <span title="{{ diceTooltip.damageExplain }}" class="roll roll-damage">{{{ diceTooltip.damage }}}</span>
-  {{else}}
-  <div class="flex-center" data-tooltip="{{diceTooltip.damageExplain}}">
-    <button class="dmgroll" data-flagns="swnr" data-flagkey="damageRoll">Roll Damage: {{diceTooltip.damageFormula}}</button>
-  </div>
-  {{/if}}
-  
-  {{#if (ne shock_content null)}}
-   {{ shock_content }}
-   <span class="roll roll-shock roll-damage">{{{ shock_roll }}}</span>
-  {{/if}}
-  {{#if (ne weapon.system.ammo.type 'none')}}
-    {{#if (ne weapon.system.ammo.type 'infinite')}}
-      <div class="ammo-{{ ammoRatio }}">
-        {{localize 'swnr.weapon.ammo'}}: {{ weapon.system.ammo.value }}/{{
-        weapon.system.ammo.max }}
-      </div>
-    {{/if}}
-  {{/if}}
+  <span title="{{ damageExplain }}" class="roll roll-damage">{{{ damage }}}</span>
+
   {{#if weapon.system.qualities}}
   <div>{{localize 'swnr.sheet.ship.qualities'}}: {{ weapon.system.qualities }}</div>
   {{/if}}

--- a/templates/chat/power-usage.hbs
+++ b/templates/chat/power-usage.hbs
@@ -1,5 +1,5 @@
 <div class="chat-card power-usage">
-  <h3 title="{{ power.system.description }}">{{ power.name }}</h3>
+  <h4 title="{{ power.system.description }}">{{ power.name }}</h4>
 
   {{! Show resource costs if resources were spent }}
   {{#if consumptions}}

--- a/templates/chat/program-roll.hbs
+++ b/templates/chat/program-roll.hbs
@@ -1,7 +1,7 @@
 <div class="chat-card">
-  <h3 title="{{ program.data.data.description }}">
+  <h4 title="{{ program.data.data.description }}">
     {{ program.name }}
-  </h3>
+  </h4>
 
   <div class="chat-desc">
     {{#if (wouldTrim program.system.description 200)}}

--- a/templates/chat/re-roll.hbs
+++ b/templates/chat/re-roll.hbs
@@ -1,5 +1,5 @@
 <div>
-  <h3>{{ title }}</h3>
+  <h4>{{ title }}</h4>
   <span class="re-roll  
   {{#if isAttack }}
   roll-damage

--- a/templates/chat/save-throw.hbs
+++ b/templates/chat/save-throw.hbs
@@ -10,4 +10,7 @@
    {{save_text}}</h4>
   <span >{{{ saveRoll }}}</span>
 
+  {{#if stressUpdate}}
+    <p>{{stressUpdate}}</p>
+  {{/if}}
 </div>

--- a/templates/chat/save-throw.hbs
+++ b/templates/chat/save-throw.hbs
@@ -1,5 +1,5 @@
 <div>
-  <h3>{{ title }}</h3>
+  <h4>{{ title }}</h4>
   <h4
    {{#if success}}
     style="color:green;"

--- a/templates/chat/sensor-roll.hbs
+++ b/templates/chat/sensor-roll.hbs
@@ -1,5 +1,5 @@
 <div>
-  <h3>Sensor Roll as {{ typeDesc }}</h3>
+  <h4>Sensor Roll as {{ typeDesc }}</h4>
   <span title="{{ skillRollStr }}">{{{ skillRoll }}}</span>
   {{#if opposedRoll}}
   <span> Other Ship ({{ otherDesc }}) </span>

--- a/templates/chat/spike-roll.hbs
+++ b/templates/chat/spike-roll.hbs
@@ -1,5 +1,5 @@
 <div>
-  <h3>Spike Drill</h3>
+  <h4>Spike Drill</h4>
   <span title="{{ skillRollStr }}">{{{ skillRoll }}}</span>
   {{#if pass}}
     <span><b>Spike drill successful.</b></span><br>

--- a/templates/chat/welcome.hbs
+++ b/templates/chat/welcome.hbs
@@ -1,5 +1,5 @@
 <div class="chat-card">
-  <h3>Welcome to the Systems Without Number (Redux) for Foundry VTT (SWN/CWN/AWN/WWN)</h3> 
+  <h4>Welcome to the Systems Without Number (Redux) for Foundry VTT (SWN/CWN/AWN/WWN)</h4> 
   <p>AWN and CWN settings (i.e., stress and trauma) may need to be set in the system settings. AWN and WWN features are in progress.</p>
   
   <p><b>If this is the first time using an old game you will need to refresh your browser (f5 or reload) for foci and edges to show up with the new item type "feature".</b></p>

--- a/templates/dialogs/add-currency-type.hbs
+++ b/templates/dialogs/add-currency-type.hbs
@@ -27,7 +27,7 @@
   <div class="form-group">
     <label>Name/Location:</label>
     <input type="text" name="currencyName" placeholder="Enter a name or location" value="{{currency.name}}" />
-    <p class="hint">A custom name for the currency, if not provided, the currency type name will be used. For example, "Bank", "Debt", etc.</p>
+    <p class="hint">A custom name for the currency. For example, "Bank", "Debt", etc.</p>
 
   </div>
   <div class="form-group">
@@ -39,7 +39,7 @@
       value="0"
       {{/if}}
     />
-    <p class="hint">The initial value/count of the currency.</p>
+    <p class="hint">The value/count of the currency.</p>
   </div>
   <div class="form-group">
     <label>Carried:</label>

--- a/templates/dialogs/add-currency-type.hbs
+++ b/templates/dialogs/add-currency-type.hbs
@@ -1,0 +1,49 @@
+<form class="currency-add-dialog">
+
+  <div class="form-group">
+    <label>Currency Type:</label>
+    <div class="form-fields">
+      <select name="currencyType">
+        <option value="base" {{#if (eq currency.type 'base')}}selected{{/if}}>{{settings.currency.baseCurrencyName}}</option>
+        {{#if settings.currency.customCurrencyName0}}
+        <option value="0" {{#if (eq currency.type '0')}}selected{{/if}}>{{settings.currency.customCurrencyName0}}</option>
+        {{/if}}
+        {{#if settings.currency.customCurrencyName1}}
+        <option value="1" {{#if (eq currency.type '1')}}selected{{/if}}>{{settings.currency.customCurrencyName1}}</option>
+        {{/if}}
+        {{#if settings.currency.customCurrencyName2}}
+        <option value="2" {{#if (eq currency.type '2')}}selected{{/if}}>{{settings.currency.customCurrencyName2}}</option>
+        {{/if}}
+        {{#if settings.currency.customCurrencyName3}}
+        <option value="3" {{#if (eq currency.type '3')}}selected{{/if}}>{{settings.currency.customCurrencyName3}}</option>
+        {{/if}}
+        {{#if settings.currency.customCurrencyName4}}
+        <option value="4" {{#if (eq currency.type '4')}}selected{{/if}}>{{settings.currency.customCurrencyName4}}</option>
+        {{/if}}
+      </select>
+    </div>
+    <p class="hint">Currency type to add. Options set by GM in settings.</p>
+  </div>
+  <div class="form-group">
+    <label>Name/Location:</label>
+    <input type="text" name="currencyName" placeholder="Enter a name or location" value="{{currency.name}}" />
+    <p class="hint">A custom name for the currency, if not provided, the currency type name will be used. For example, "Bank", "Debt", etc.</p>
+
+  </div>
+  <div class="form-group">
+    <label>Currency Value:</label>
+    <input type="number" name="currencyValue" 
+      {{#if currency.value}}
+      value="{{currency.value}}" 
+      {{else}}
+      value="0"
+      {{/if}}
+    />
+    <p class="hint">The initial value/count of the currency.</p>
+  </div>
+  <div class="form-group">
+    <label>Carried:</label>
+    <input type="checkbox" name="carried" {{#if currency.carried}}checked{{/if}} />
+    <p class="hint">Check if the currency is carried by the character, may take up stowed slots.</p>
+  </div>
+</form>

--- a/templates/dialogs/add-currency-type.hbs
+++ b/templates/dialogs/add-currency-type.hbs
@@ -22,7 +22,7 @@
         {{/if}}
       </select>
     </div>
-    <p class="hint">Currency type to add. Options set by GM in settings.</p>
+    <p class="hint">Currency type to add. Options set by GM in settings. Does not convert on change.</p>
   </div>
   <div class="form-group">
     <label>Name/Location:</label>

--- a/templates/dialogs/currency-settings.hbs
+++ b/templates/dialogs/currency-settings.hbs
@@ -1,11 +1,60 @@
-<div class="flexcol standard-form">
-  {{!-- <div class="form-group">
-    <label for="baseCurrencyName">Base Currency Name</label>
-    <input type="text" name="baseCurrencyName" value="{{baseCurrencyName}}">
-  </div> --}}
+<div class="flexcol standard-form settings-form">
+  <div class="settings-form">
+    <h4>Currency Settings for the World</h4>
+    <p class="hint">Configure the currency system for the world. This will affect all currencies in the world, it will not automatically run conversions for existing currencies.</p>
+  </div>
+  <div class="form-group">
+    <label>Load Preset:</label>
+    <div class="form-fields">
+      <select name="loadPreset">
+        <option value="none">None/Custom</option>
+        <option value="swn">SWN (Base is Credits only)</option>
+        <option value="cwn">CWN (Base is Dollars only)</option>
+        <option value="awn">AWN Zone (Gold Escudo, Silver Peso, Mandate Credit, Ration)</option>
+        <option value="wwn">WWN (Silver Standard with Gold and Copper)</option>
+        <option value="ose">OSE (Gold Standard, Platinum, Silver, Copper, and Electrum)</option>
+      </select>
+    </div>
+    <p class="hint">Load default currencies. <b>Warning:</b> this will overwrite all custom currencies if you save!</p>
+  </div>
 
 
- {{formGroup fields.baseCurrencyName value=settings.currency.baseCurrencyName localize=true}}
- {{formGroup fields.baseCurrencyEnc value=settings.currency.baseCurrencyEnc localize=true}}
+  {{formGroup fields.baseCurrencyName value=settings.currency.baseCurrencyName localize=true}}
+  {{formGroup fields.baseCurrencyEnc value=settings.currency.baseCurrencyEnc localize=true}}
 
+  <div class="custom-currency-container">
+    <h4>Custom Currency 1</h4>
+    {{formGroup fields.customCurrencyName0 value=settings.currency.customCurrencyName0 localize=true}}
+    {{formGroup fields.customCurrencyEnc0 value=settings.currency.customCurrencyEnc0 localize=true}}
+    {{formGroup fields.customCurrencyConversionRate0 value=settings.currency.customCurrencyConversionRate0
+    localize=true}}
+  </div>
+  <div class="custom-currency-container">
+    <h4>Custom Currency 2</h4>
+    {{formGroup fields.customCurrencyName1 value=settings.currency.customCurrencyName1 localize=true}}
+    {{formGroup fields.customCurrencyEnc1 value=settings.currency.customCurrencyEnc1 localize=true}}
+    {{formGroup fields.customCurrencyConversionRate1 value=settings.currency.customCurrencyConversionRate1
+    localize=true}}
+  </div>
+  <div class="custom-currency-container">
+    <h4>Custom Currency 3</h4>
+    {{formGroup fields.customCurrencyName2 value=settings.currency.customCurrencyName2 localize=true}}
+    {{formGroup fields.customCurrencyEnc2 value=settings.currency.customCurrencyEnc2 localize=true}}
+    {{formGroup fields.customCurrencyConversionRate2 value=settings.currency.customCurrencyConversionRate2
+    localize=true}}
+  </div>
+  <div class="custom-currency-container">
+    <h4>Custom Currency 4</h4>
+    {{formGroup fields.customCurrencyName3 value=settings.currency.customCurrencyName3 localize=true}}
+    {{formGroup fields.customCurrencyEnc3 value=settings.currency.customCurrencyEnc3 localize=true}}
+    {{formGroup fields.customCurrencyConversionRate3 value=settings.currency.customCurrencyConversionRate3
+    localize=true}}
+  </div>
+  <div class="custom-currency-container">
+    <h4>Custom Currency 5</h4>
+    {{formGroup fields.customCurrencyName4 value=settings.currency.customCurrencyName4 localize=true}}
+    {{formGroup fields.customCurrencyEnc4 value=settings.currency.customCurrencyEnc4 localize=true}}
+    {{formGroup fields.customCurrencyConversionRate4 value=settings.currency.customCurrencyConversionRate4
+    localize=true}}
+  </div>
 </div>

--- a/templates/dialogs/currency-settings.hbs
+++ b/templates/dialogs/currency-settings.hbs
@@ -15,7 +15,7 @@
         <option value="ose">OSE (Gold Standard, Platinum, Silver, Copper, and Electrum)</option>
       </select>
     </div>
-    <p class="hint">Load default currencies. <b>Warning:</b> this will overwrite all custom currencies if you save!</p>
+    <p class="hint">Load default currencies. <b>Warning:</b> this will overwrite all custom currencies if you change!</p>
   </div>
 
 

--- a/templates/dialogs/currency-settings.hbs
+++ b/templates/dialogs/currency-settings.hbs
@@ -1,0 +1,11 @@
+<div class="flexcol standard-form">
+  {{!-- <div class="form-group">
+    <label for="baseCurrencyName">Base Currency Name</label>
+    <input type="text" name="baseCurrencyName" value="{{baseCurrencyName}}">
+  </div> --}}
+
+
+ {{formGroup fields.baseCurrencyName value=settings.currency.baseCurrencyName localize=true}}
+ {{formGroup fields.baseCurrencyEnc value=settings.currency.baseCurrencyEnc localize=true}}
+
+</div>

--- a/templates/item/description.hbs
+++ b/templates/item/description.hbs
@@ -4,6 +4,25 @@
   data-group='primary'
   data-tab='description'
 >
+<!-- check if GM --> 
+{{#if (or isGM system.showGMNotes)}}
+<div class="flex flex-col">
+  <div class="grid grid-cols-2">
+    <span><h4 style="margin-bottom: 2px;">GM Notes</h4></span>
+    {{#if isGM}}
+    <span>GM notes visible to players: 
+      {{formInput systemFields.showGMNotes value=system.showGMNotes}}
+    </span>
+    {{/if}}
+  </div>
+  <div class="grid-span-2">
+    <textarea name="system.gmNotes" rows="4" cols="40" {{#unless isGM}}readonly{{/unless}}>{{system.gmNotes}}</textarea>
+  </div>
+</div>
+{{/if}}
+
+
+<h4 style="margin: 2px;">Description</h4>
   {{! Editors must receive enriched text data from getData to properly handle rolls, UUID links, etc. }}
   <div class="editor">
     {{#if editable}} 
@@ -17,4 +36,7 @@
       {{/if}}
     </div>
   </div>
+
+
+
 </section>


### PR DESCRIPTION
- Custom currency system configuration supported. Base currency and up to 5 custom currencies. Old debt, balance, and owed fields are deprecated and will be removed in a future version.  They should be migrated to the new system, but the old values are shown in the tweaks section as readonly.
- Added readied and stowed modifiers to character sheet (under features/tweaks)
- Fixed capt support department bug
- Added stress button to character sheet to modify and roll stress, along with tracking breakdowns (page 57 of AWN).
- Auto show power type on features tab when type is first added
- Setting to not roll damage/trauma dice on attack roll automatically with button to roll
- Added GM notes to item description (under description tab). GM notes are hidden by default and can be shown to players by checking the box.