### PR TITLE
Foundry VTT v14 compatibility

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -110,6 +110,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "illyja",
+      "name": "Ilija Anastasijevi\u0107",
+      "avatar_url": "https://avatars.githubusercontent.com/u/21970862?v=4",
+      "profile": "https://github.com/illyja",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,13 @@
 # Repository Guidelines (Concise)
 
-## Foundry V13 ApplicationV2
-- No jQuery: use native DOM (`querySelector`, `addEventListener`).
+## Core Version Target
+`system.json` declares `minimum: 13.345`, `verified: 14.365` — code must run on both.
+**See `CLAUDE.md` for the authoritative v13/v14 compatibility rules** (namespaced globals,
+`prepareBaseData` super call, chat message visibility and roll attachment). Those rules are
+maintained in one place to stop the agent docs drifting apart.
+
+## Foundry ApplicationV2
+- Prefer native DOM in new code (`querySelector`, `addEventListener`).
 - No `submitOnChange`: wire listeners in `_onRender()`.
 - Static action handlers: `static async _onActionHandler(event, target)`.
 - Templates must have a single root element.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ works on both v13 and v14.
   `roll:` field produced an empty `message.rolls` (breaking Dice So Nice and anything
   reading rolls off the message); all senders now use `rolls: [...]`.
 - Creating a new weapon threw on partial source data in `migrateData()`. (Thanks @illyja)
+- **The ship sensor roll never posted on v14.** Its dialog offered hardcoded v13 mode
+  strings and passed them into the chat API, which rejects unrecognised modes; the roll
+  threw before reaching chat. The same message also set the message-style enum on `type`
+  (the document subtype, which only accepts `"base"`) rather than `style`, which made
+  `create()` silently fail. Both fixed; public, private and blind sensor rolls all work.
+- Ship weapon migration aborted halfway on any item predating the `trauma` field — the
+  same unguarded access already fixed for weapons. Because core wraps `migrateData()` in a
+  try/catch this failed silently, skipping the stat migration below it.
+- Power chat cards were not roll messages (no Dice So Nice, empty `rolls`); they were the
+  last holdout still using the legacy singular `roll:` field.
 
 ### Compatibility
 - Migrated deprecated globals removed in v15 to their namespaces: document collections and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to the Systems Without Number Redux (SWNR) system for Foundr
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] Foundry VTT v14 compatibility
+
+Verified against Foundry v14.365. Minimum supported core remains 13.345 — everything below
+works on both v13 and v14.
+
+### Fixes
+- **Actors could not be created or loaded on v14.** `SWNActor.prepareBaseData()` overrode
+  core without calling `super`, skipping the `_clearData()` that initializes
+  `tokenActiveEffectChanges`, so active-effect application threw during document
+  initialization. (Thanks @illyja)
+- **Private and blind rolls were posted publicly on v14.** v14 renamed the `core.rollMode`
+  setting to `core.messageMode` and changed its values; the old key still exists but reads
+  back `null`, so every chat message was built with no whisper targets regardless of the
+  GM's selected mode. Visibility now resolves through version-aware helpers.
+- **Reroll buttons never appeared on v14.** The handler selected `.roll`, which core now
+  puts on each individual die rather than the roll container (`.dice-roll`).
+- **Rolls were missing from several chat cards.** Messages using the legacy singular
+  `roll:` field produced an empty `message.rolls` (breaking Dice So Nice and anything
+  reading rolls off the message); all senders now use `rolls: [...]`.
+- Creating a new weapon threw on partial source data in `migrateData()`. (Thanks @illyja)
+
+### Compatibility
+- Migrated deprecated globals removed in v15 to their namespaces: document collections and
+  AppV1 sheet classes, `renderTemplate`/`loadTemplates`, `TextEditor`, and `DragDrop`.
+  (`TextEditor`/`DragDrop` thanks @illyja)
+- Moved from the deprecated `renderChatMessage` hook to `renderChatMessageHTML`.
+- Replaced `ChatMessage.applyRollMode()` and `CONST.DICE_ROLL_MODES` (deprecated in v14).
+- System now loads with no deprecation warnings or errors on v14.
+
+### Docs
+- `CLAUDE.md` documents the v13/v14 compatibility rules; `AGENTS.md` and `GEMINI.md` now
+  point at it instead of keeping their own drifting copies.
+
 ## [2.3.0] 2025-11-04 More XWN support
 
 - Custom currency system configuration supported. Base currency and up to 5 custom currencies. Old debt, balance, and owed fields are deprecated and will be removed in a future version.  They should be migrated to the new system, but the old values are shown in the tweaks section as readonly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,50 @@
 
 Concise guidance for Claude Code on this Foundry VTT v13+/v14 system.
 
-## V13+/V14 Essentials
-- No jQuery; use native DOM APIs.
-- UX helpers are namespaced under `foundry.applications.ux`: use
-  `foundry.applications.ux.TextEditor.implementation` (e.g. `.enrichHTML`,
-  `.getDragEventData`) and `foundry.applications.ux.DragDrop.implementation`,
-  not the bare `TextEditor` / `DragDrop` globals (deprecated since v13, removed in v15).
+## Core Version Target
+
+`system.json` declares `minimum: 13.345`, `verified: 14.365`. **Code must run on both
+v13 and v14** — when an API differs between them, add a small compat helper rather than
+branching inline or dropping v13.
+
+## Namespaced Globals
+
+Bare globals still work on v14 but are removed in v15. Always use the namespaced form:
+
+| Deprecated global | Use instead |
+|---|---|
+| `Actors`, `Items` | `foundry.documents.collections.*` |
+| `ActorSheet`, `ItemSheet` | `foundry.appv1.sheets.*` |
+| `renderTemplate`, `loadTemplates` | `foundry.applications.handlebars.*` |
+| `TextEditor` | `foundry.applications.ux.TextEditor.implementation` |
+| `DragDrop` | `new foundry.applications.ux.DragDrop.implementation(...)` |
+
+## Document Lifecycle
+
+- **Always call `super` in `prepareBaseData()`.** Core's implementation runs `_clearData()`,
+  which initializes `overrides`, `statuses`, and `tokenActiveEffectChanges`. Skipping it
+  makes `applyActiveEffects()` throw during document construction on v14.
+- Guard optional data in `static migrateData()` — it receives partial source data for
+  newly-created documents (e.g. check `data.trauma` before reading `data.trauma.rating`).
+
+## Chat Messages
+
+- **Visibility:** never read `core.rollMode` directly. v14 renamed the setting to
+  `core.messageMode` and changed its values (`gmroll` → `gm`, etc.); the old key still
+  exists but reads back `null`, which silently makes private rolls public. Use the
+  helpers in `helpers/utils.mjs`: `getChatMessageMode()`, `applyChatMessageMode(chatData)`,
+  and `chatMode("gm")` for an explicit visibility.
+- **Rolls:** attach rolls with `rolls: [roll]`. The legacy singular `roll:` field is no
+  longer honoured, leaving `message.rolls` empty (breaks Dice So Nice and roll inspection).
+- **Hook:** listen to `renderChatMessageHTML`, not `renderChatMessage`. It passes an
+  `HTMLElement` where the old hook passed jQuery.
+- **Markup:** the roll container is `.dice-roll`; `.roll` is on each individual die
+  (`<li class="roll die d20">`). Selecting `.roll` for a container finds nothing.
+
+## Application / Sheet Conventions
+
+- Prefer native DOM APIs in new code. (`helpers/chat.mjs` is still jQuery-based and is
+  adapted at the hook boundary; porting it is tracked separately.)
 - Don’t rely on `submitOnChange`; wire listeners in `_onRender()`.
 - Static action handlers only.
 - Templates need a single root element.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,13 @@
 # CLAUDE.md
 
-Concise guidance for Claude Code on this Foundry VTT v13 system.
-Concise guidance for Claude Code on this Foundry VTT v13 system.
+Concise guidance for Claude Code on this Foundry VTT v13+/v14 system.
 
-## V13 Essentials
+## V13+/V14 Essentials
 - No jQuery; use native DOM APIs.
+- UX helpers are namespaced under `foundry.applications.ux`: use
+  `foundry.applications.ux.TextEditor.implementation` (e.g. `.enrichHTML`,
+  `.getDragEventData`) and `foundry.applications.ux.DragDrop.implementation`,
+  not the bare `TextEditor` / `DragDrop` globals (deprecated since v13, removed in v15).
 - Don’t rely on `submitOnChange`; wire listeners in `_onRender()`.
 - Static action handlers only.
 - Templates need a single root element.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,9 +1,15 @@
 # GEMINI.md
 
-Concise guidance for Gemini on this Foundry VTT v13 system.
+Concise guidance for Gemini on this Foundry VTT v13+/v14 system.
 
-## V13 Essentials
-- No jQuery; use native DOM APIs.
+## Core Version Target
+`system.json` declares `minimum: 13.345`, `verified: 14.365` — code must run on both.
+**See `CLAUDE.md` for the authoritative v13/v14 compatibility rules** (namespaced globals,
+`prepareBaseData` super call, chat message visibility and roll attachment). Those rules are
+maintained in one place to stop the agent docs drifting apart.
+
+## Essentials
+- Prefer native DOM APIs in new code.
 - Don’t rely on `submitOnChange`; wire listeners in `_onRender()`.
 - Static action handlers only.
 - Templates need a single root element.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Torticute"><img src="https://avatars.githubusercontent.com/u/30007326?v=4?s=100" width="100px;" alt="Torticute"/><br /><sub><b>Torticute</b></sub></a><br /><a href="https://github.com/wintersleepAI/swnr/commits?author=Torticute" title="Tests">⚠️</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/pgotsis"><img src="https://avatars.githubusercontent.com/u/7128789?v=4?s=100" width="100px;" alt="Panos Gotsis"/><br /><sub><b>Panos Gotsis</b></sub></a><br /><a href="https://github.com/wintersleepAI/swnr/commits?author=pgotsis" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/pandanielxd"><img src="https://avatars.githubusercontent.com/u/65407753?v=4?s=100" width="100px;" alt="pandanielxd"/><br /><sub><b>pandanielxd</b></sub></a><br /><a href="https://github.com/wintersleepAI/swnr/commits?author=pandanielxd" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/illyja"><img src="https://avatars.githubusercontent.com/u/21970862?v=4?s=100" width="100px;" alt="Ilija Anastasijević"/><br /><sub><b>Ilija Anastasijević</b></sub></a><br /><a href="https://github.com/wintersleepAI/swnr/commits?author=illyja" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/module/data/actors/actor-character.mjs
+++ b/module/data/actors/actor-character.mjs
@@ -1,7 +1,6 @@
 import SWNActorBase from './base-actor.mjs';
 import SWNShared from '../shared.mjs';
-import { calcMod } from '../../helpers/utils.mjs';
-
+import { calcMod, applyChatMessageMode, getChatMessageMode } from '../../helpers/utils.mjs';
 export default class SWNCharacter extends SWNActorBase {
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
@@ -332,11 +331,11 @@ export default class SWNCharacter extends SWNActorBase {
       throwType: game.i18n.localize("swnr.sheet.saves." + saveType),
     });
     const dialogData = {};
-    const html = await renderTemplate(template, dialogData);
+    const html = await foundry.applications.handlebars.renderTemplate(template, dialogData);
 
     //Callback for rolling
     const _doRoll = async (_event, button, _html) => {
-      const rollMode = game.settings.get("core", "rollMode");
+      const rollMode = getChatMessageMode();
       const modifier = parseInt(button.form.elements.modifier?.value);
       if (isNaN(modifier)) {
         ui.notifications?.error(`Error, modifier is not a number ${modString}`);
@@ -363,14 +362,13 @@ export default class SWNCharacter extends SWNActorBase {
         save_text,
         success,
       };
-      const chatContent = await renderTemplate(chatTemplate, chatDialogData);
+      const chatContent = await foundry.applications.handlebars.renderTemplate(chatTemplate, chatDialogData);
       const chatData = {
         speaker: ChatMessage.getSpeaker(),
-        roll: JSON.stringify(roll),
         rolls: [roll],
         content: chatContent
       };
-      getDocumentClass("ChatMessage").applyRollMode(chatData, rollMode);
+      applyChatMessageMode(chatData, rollMode);
       getDocumentClass("ChatMessage").create(chatData);
     };
     const popUpDialog = await foundry.applications.api.DialogV2.prompt(
@@ -435,7 +433,6 @@ export default class SWNCharacter extends SWNActorBase {
         getDocumentClass("ChatMessage").create({
           speaker: ChatMessage.getSpeaker({ actor: this.parent }),
           flavor: msg,
-          roll: JSON.stringify(roll),
           rolls: [roll],
         });
       } else {
@@ -654,7 +651,7 @@ export default class SWNCharacter extends SWNActorBase {
     const title = game.i18n.format("swnr.titles.savingThrow", {
       throwType: game.i18n.localize("swnr.sheet.saves.mental") + " (Stress)"
     });
-    const rollMode = game.settings.get("core", "rollMode");
+    const rollMode = getChatMessageMode();
 
 
     const formula = `1d20`;
@@ -697,14 +694,13 @@ export default class SWNCharacter extends SWNActorBase {
       success,
       stressUpdate
     };
-    const chatContent = await renderTemplate(chatTemplate, chatDialogData);
+    const chatContent = await foundry.applications.handlebars.renderTemplate(chatTemplate, chatDialogData);
     const chatData = {
       speaker: ChatMessage.getSpeaker(),
-      roll: JSON.stringify(roll),
       rolls: [roll],
       content: chatContent,
     };
-    getDocumentClass("ChatMessage").applyRollMode(chatData, rollMode);
+    applyChatMessageMode(chatData, rollMode);
     getDocumentClass("ChatMessage").create(chatData);
 
 

--- a/module/data/actors/actor-ship.mjs
+++ b/module/data/actors/actor-ship.mjs
@@ -1,5 +1,6 @@
 import SWNVehicleBase from './base-vehicle.mjs';
 import SWNShared from '../shared.mjs';
+import { applyChatMessageMode, getChatMessageMode } from '../../helpers/utils.mjs';
 
 
 export default class SWNShip extends SWNVehicleBase {
@@ -206,7 +207,7 @@ export default class SWNShip extends SWNVehicleBase {
       otherDesc,
     };
     const diceData = Roll.fromTerms([foundry.dice.terms.PoolTerm.fromRolls(poolRolls)]);
-    const chatContent = await renderTemplate(template, dialogData);
+    const chatContent = await foundry.applications.handlebars.renderTemplate(template, dialogData);
   
     let gm_ids = ChatMessage.getWhisperRecipients("GM")
       .filter((i) => i)
@@ -221,14 +222,14 @@ export default class SWNShip extends SWNVehicleBase {
     }
     const chatData = {
       speaker: { alias: actorName },
-      roll: JSON.stringify(diceData),
+      rolls: [diceData],
       content: chatContent,
       type: CONST.CHAT_MESSAGE_STYLES.OTHER,
       whisper: gm_ids,
       blind,
     };
   
-    getDocumentClass("ChatMessage").applyRollMode(chatData, rollMode);
+    applyChatMessageMode(chatData, rollMode);
     getDocumentClass("ChatMessage").create(chatData);
   }
   
@@ -300,20 +301,20 @@ export default class SWNShip extends SWNVehicleBase {
       failText,
       pilotName,
     };
-    const rollMode = game.settings.get("core", "rollMode");
+    const rollMode = getChatMessageMode();
     const poolRolls = [skillRoll];
     if (failRoll) {
       poolRolls.push(failRoll);
     }
     const diceData = Roll.fromTerms([foundry.dice.terms.PoolTerm.fromRolls(poolRolls)]);
-    const chatContent = await renderTemplate(template, dialogData);
+    const chatContent = await foundry.applications.handlebars.renderTemplate(template, dialogData);
     const chatData = {
       speaker: { alias: pilotName },
-      roll: JSON.stringify(diceData),
+      rolls: [diceData],
       content: chatContent
     };
   
-    getDocumentClass("ChatMessage").applyRollMode(chatData, rollMode);
+    applyChatMessageMode(chatData, rollMode);
     getDocumentClass("ChatMessage").create(chatData);
   
     this.useDaysOfLifeSupport(travelDays);

--- a/module/data/actors/actor-ship.mjs
+++ b/module/data/actors/actor-ship.mjs
@@ -1,6 +1,6 @@
 import SWNVehicleBase from './base-vehicle.mjs';
 import SWNShared from '../shared.mjs';
-import { applyChatMessageMode, getChatMessageMode } from '../../helpers/utils.mjs';
+import { applyChatMessageMode, chatMode, getChatMessageMode } from '../../helpers/utils.mjs';
 
 
 export default class SWNShip extends SWNVehicleBase {
@@ -215,21 +215,25 @@ export default class SWNShip extends SWNVehicleBase {
       .filter((i) => i !== null);
     let blind = false;
   
-    if (rollMode == "roll") {
+    // rollMode here is a semantic mode from the sensor dialog ("public"/"gm"/
+    // "blind"), translated to the running core's vocabulary by chatMode() below.
+    if (rollMode == "public") {
       gm_ids = null;
-    } else if (rollMode == "blindroll") {
+    } else if (rollMode == "blind") {
       blind = true;
     }
     const chatData = {
       speaker: { alias: actorName },
       rolls: [diceData],
       content: chatContent,
-      type: CONST.CHAT_MESSAGE_STYLES.OTHER,
+      // CHAT_MESSAGE_STYLES belongs on `style`; `type` is the document subtype
+      // and only accepts "base", so a numeric `type` silently rejects create().
+      style: CONST.CHAT_MESSAGE_STYLES.OTHER,
       whisper: gm_ids,
       blind,
     };
   
-    applyChatMessageMode(chatData, rollMode);
+    applyChatMessageMode(chatData, chatMode(rollMode));
     getDocumentClass("ChatMessage").create(chatData);
   }
   

--- a/module/data/items/item-power.mjs
+++ b/module/data/items/item-power.mjs
@@ -458,7 +458,7 @@ export default class SWNPower extends SWNItemBase {
     const chatData = {
       speaker: ChatMessage.getSpeaker({ actor: actor }),
       content: chatContent,
-      roll: powerRoll ? JSON.stringify(powerRoll) : null
+      rolls: powerRoll ? [powerRoll] : []
     };
 
     applyChatMessageMode(chatData, rollMode);

--- a/module/data/items/item-power.mjs
+++ b/module/data/items/item-power.mjs
@@ -1,5 +1,6 @@
 import SWNItemBase from './base-item.mjs';
 import SWNShared from '../shared.mjs';
+import { applyChatMessageMode, getChatMessageMode } from '../../helpers/utils.mjs';
 
 export default class SWNPower extends SWNItemBase {
   static LOCALIZATION_PREFIXES = [
@@ -415,7 +416,7 @@ export default class SWNPower extends SWNItemBase {
   async _createPowerChatCard(powerRoll = null, consumptionResults = []) {
     const item = this.parent;
     const actor = item.actor;
-    const rollMode = game.settings.get("core", "rollMode");
+    const rollMode = getChatMessageMode();
 
     // Calculate strain cost from consumption results
     const totalStrainCost = consumptionResults
@@ -460,7 +461,7 @@ export default class SWNPower extends SWNItemBase {
       roll: powerRoll ? JSON.stringify(powerRoll) : null
     };
 
-    getDocumentClass("ChatMessage").applyRollMode(chatData, rollMode);
+    applyChatMessageMode(chatData, rollMode);
     return chatData;
   }
 
@@ -514,16 +515,16 @@ export default class SWNPower extends SWNItemBase {
       hasUnprocessedConsumableManual: hasManualConsumables,
       consumableRequirements
     };
-    const rollMode = game.settings.get("core", "rollMode");
+    const rollMode = getChatMessageMode();
 
     const template = "systems/swnr/templates/chat/power-usage.hbs";
     const chatContent = await foundry.applications.handlebars.renderTemplate(template, dialogData);
     const chatData = {
       speaker: ChatMessage.getSpeaker({ actor: actor ?? undefined }),
       content: chatContent,
-      roll: JSON.stringify(powerRoll)
+      rolls: [powerRoll]
     };
-    getDocumentClass("ChatMessage").applyRollMode(chatData, rollMode);
+    applyChatMessageMode(chatData, rollMode);
     getDocumentClass("ChatMessage").create(chatData);
   }
 
@@ -884,7 +885,7 @@ export default class SWNPower extends SWNItemBase {
       value: i.system?.uses?.value || 0,
       max: i.system?.uses?.max || (i.system?.uses?.value || 0)
     }));
-    const content = await renderTemplate(template, { items });
+    const content = await foundry.applications.handlebars.renderTemplate(template, { items });
 
     return new Promise((resolve) => {
       const dialogId = `swnr-consume-select-${actor.id}-${Date.now()}`;

--- a/module/data/items/item-program.mjs
+++ b/module/data/items/item-program.mjs
@@ -1,5 +1,6 @@
 import SWNItemBase from './base-item.mjs';
 import SWNShared from '../shared.mjs';
+import { applyChatMessageMode, getChatMessageMode } from '../../helpers/utils.mjs';
 
 export default class SWNProgram extends SWNItemBase {
   static LOCALIZATION_PREFIXES = [
@@ -116,9 +117,9 @@ export default class SWNProgram extends SWNItemBase {
         && this.parent.name?.includes("Kill"),
       programSkill: "Int/Program",
     };
-    const rollMode = game.settings.get("core", "rollMode");
+    const rollMode = getChatMessageMode();
 
-    const chatContent = await renderTemplate(template, dialogData);
+    const chatContent = await foundry.applications.handlebars.renderTemplate(template, dialogData);
     // TODO: break up into two rolls and chain them?
     // const promise = game.dice3d
     //   ? game.dice3d.showForRoll(diceData)
@@ -128,7 +129,7 @@ export default class SWNProgram extends SWNItemBase {
       speaker: ChatMessage.getSpeaker({ actor: hacker ?? undefined }),
       content: chatContent
     };
-    getDocumentClass("ChatMessage").applyRollMode(chatData, rollMode);
+    applyChatMessageMode(chatData, rollMode);
     getDocumentClass("ChatMessage").create(chatData);
   }
 

--- a/module/data/items/item-ship-weapon.mjs
+++ b/module/data/items/item-ship-weapon.mjs
@@ -36,7 +36,10 @@ export default class SWNShipWeapon extends SWNVehicleItemBase {
 
   static migrateData(data) {
 
-    if (data.trauma.rating == "none" || data.trauma.rating == "") {
+    // `trauma` is absent on documents authored before it entered the schema.
+    // migrateData is wrapped in a try/catch by core, so an unguarded access
+    // here would silently abort the rest of this migration.
+    if (data.trauma && (data.trauma.rating == "none" || data.trauma.rating == "")) {
       data.trauma.rating = null;
     }
 

--- a/module/data/items/item-ship-weapon.mjs
+++ b/module/data/items/item-ship-weapon.mjs
@@ -1,5 +1,6 @@
 import SWNVehicleItemBase from './base-ship.mjs';
 import SWNShared from '../shared.mjs';
+import { applyChatMessageMode, getChatMessageMode } from '../../helpers/utils.mjs';
 
 export default class SWNShipWeapon extends SWNVehicleItemBase {
   static LOCALIZATION_PREFIXES = [
@@ -141,7 +142,7 @@ export default class SWNShipWeapon extends SWNVehicleItemBase {
       };
 
       const template = "systems/swnr/templates/dialogs/roll-ship-attack.hbs";
-      const html = await renderTemplate(template, dialogData);
+      const html = await foundry.applications.handlebars.renderTemplate(template, dialogData);
 
       const _rollForm = async (_event, button, html) => {
         const mod = parseInt(button.form.elements.modifier.value);
@@ -308,7 +309,7 @@ export default class SWNShipWeapon extends SWNVehicleItemBase {
         traumaRollRender,
       };
 
-      const rollMode = game.settings.get("core", "rollMode");
+      const rollMode = getChatMessageMode();
       // const dice = hitRoll.dice.concat(damageRoll.dice)
       // const formula = dice.map(d => (<any>d).formula).join(' + ');
       // const results = dice.reduce((a, b) => a.concat(b.results), [])
@@ -316,13 +317,13 @@ export default class SWNShipWeapon extends SWNVehicleItemBase {
         foundry.dice.terms.PoolTerm.fromRolls([hitRoll, damageRoll]),
       ]);
 
-      const chatContent = await renderTemplate(template, dialogData);
+      const chatContent = await foundry.applications.handlebars.renderTemplate(template, dialogData);
       const chatData = {
         speaker: { alias: shooterName },
-        roll: JSON.stringify(diceData),
+        rolls: [diceData],
         content: chatContent
       };
-      getDocumentClass("ChatMessage").applyRollMode(chatData, rollMode);
+      applyChatMessageMode(chatData, rollMode);
       getDocumentClass("ChatMessage").create(chatData);
     }
 

--- a/module/data/items/item-skill.mjs
+++ b/module/data/items/item-skill.mjs
@@ -1,5 +1,6 @@
 import SWNItemBase from './base-item.mjs';
 import SWNShared from '../shared.mjs';
+import { getChatMessageMode } from '../../helpers/utils.mjs';
 
 export default class SWNSkill extends SWNItemBase {
   static LOCALIZATION_PREFIXES = [
@@ -57,7 +58,7 @@ export default class SWNSkill extends SWNItemBase {
     skillRank,
     modifier
   ) {
-    const rollMode = game.settings.get("core", "rollMode");
+    const rollMode = getChatMessageMode();
 
     const formula = `${dice} + @stat + @skill + @modifier`;
     const roll = new Roll(formula, {
@@ -135,7 +136,7 @@ export default class SWNSkill extends SWNItemBase {
       stats: actor.system.stats
     };
 
-    const content = await renderTemplate(template, dialogData);
+    const content = await foundry.applications.handlebars.renderTemplate(template, dialogData);
     const _doRoll = async (_event, button, html) => {
       const dice = button.form.elements.dicepool.value;
       const statShortNameForm = button.form.elements.stat.value;

--- a/module/data/items/item-weapon.mjs
+++ b/module/data/items/item-weapon.mjs
@@ -56,7 +56,7 @@ export default class SWNWeapon extends SWNBaseGearItem {
 
   static migrateData(data) {
 
-    if (data.trauma.rating == "none" || data.trauma.rating == "") {
+    if (data.trauma && (data.trauma.rating == "none" || data.trauma.rating == "")) {
       data.trauma.rating = null;
     }
 

--- a/module/data/items/item-weapon.mjs
+++ b/module/data/items/item-weapon.mjs
@@ -1,5 +1,6 @@
 import SWNBaseGearItem from './base-gear-item.mjs';
 import SWNShared from '../shared.mjs';
+import { applyChatMessageMode, getChatMessageMode } from '../../helpers/utils.mjs';
 
 export default class SWNWeapon extends SWNBaseGearItem {
   static LOCALIZATION_PREFIXES = [
@@ -260,7 +261,7 @@ export default class SWNWeapon extends SWNBaseGearItem {
       traumaRollRender,
       gearCondition,
     };
-    const rollMode = game.settings.get("core", "rollMode");
+    const rollMode = getChatMessageMode();
     const diceData = Roll.fromTerms([foundry.dice.terms.PoolTerm.fromRolls(rollArray)]);
     if (
       this.ammo.type !== "none" &&
@@ -275,10 +276,9 @@ export default class SWNWeapon extends SWNBaseGearItem {
       if (newAmmoTotal === 0)
         ui.notifications?.warn(`Your ${item.name} is now out of ammo!`);
     }
-    const chatContent = await renderTemplate(template, dialogData);
+    const chatContent = await foundry.applications.handlebars.renderTemplate(template, dialogData);
     const chatData = {
       speaker: ChatMessage.getSpeaker({ actor: actor ?? undefined }),
-      roll: JSON.stringify(diceData),
       rolls: rollArray, // Added for dice so nice trigger. 
       content: chatContent
     };
@@ -297,7 +297,7 @@ export default class SWNWeapon extends SWNBaseGearItem {
         }
       };
     }
-    getDocumentClass("ChatMessage").applyRollMode(chatData, rollMode);
+    applyChatMessageMode(chatData, rollMode);
     getDocumentClass("ChatMessage").create(chatData);
   }
 
@@ -389,7 +389,7 @@ export default class SWNWeapon extends SWNBaseGearItem {
       stats: actor.system.stats,
     };
     const template = "systems/swnr/templates/dialogs/roll-attack.hbs";
-    const html = await renderTemplate(template, dialogData);
+    const html = await foundry.applications.handlebars.renderTemplate(template, dialogData);
 
     const _rollForm = async (_event, button, html) => {
       const modifier = parseInt(button.form.elements.modifier.value);

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -14,6 +14,11 @@ export class SWNActor extends Actor {
 
   /** @override */
   prepareBaseData() {
+    // Core prepareBaseData() runs _clearData(), which (as of v13/v14)
+    // initializes this.tokenActiveEffectChanges, this.overrides, statuses,
+    // and _completedActiveEffectPhases. applyActiveEffects() relies on those,
+    // so super MUST be called or effect application throws during _initialize.
+    super.prepareBaseData();
     // Data modifications in this step occur before processing embedded
     // documents or derived data.
   }
@@ -26,6 +31,7 @@ export class SWNActor extends Actor {
    * is queried and has a roll executed directly from it).
    */
   prepareDerivedData() {
+    super.prepareDerivedData();
     const actorData = this;
     const flags = actorData.flags.swnr || {};
   }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1,4 +1,5 @@
 import { ContainerHelper } from '../helpers/container-helper.mjs';
+import { getChatMessageMode } from '../helpers/utils.mjs';
 
 /**
  * Extend the basic Item with some very simple modifications.
@@ -66,7 +67,7 @@ export class SWNItem extends Item {
 
     // Initialize chat data.
     const speaker = ChatMessage.getSpeaker({ actor: this.actor });
-    const rollMode = game.settings.get('core', 'rollMode');
+    const rollMode = getChatMessageMode();
     let label = `[${item.type}] ${item.name}`;
     let description = item.system.description ?? '';
     if (game.settings.get("swnr", "useAWNGearCondition")) {

--- a/module/helpers/chat.mjs
+++ b/module/helpers/chat.mjs
@@ -1,10 +1,15 @@
+import { applyChatMessageMode, getChatMessageMode } from './utils.mjs';
 export function chatListeners(message, html) {
 //  html.on("click", "button.dmgroll", _onDmgRollClick.c(this));
   html.on("click", "button.dmgroll", (event) => _onDmgRollClick.call(this, event, message));
 
   html.on("click", ".card-buttons button", _onChatCardAction.bind(this));
-  // Add reroll buttons to all dice rolls
-  html.find(".roll").each((_i, div) => {
+  // Add reroll buttons to all dice rolls.
+  // Must target ".dice-roll" (the roll container holding .dice-formula and
+  // .dice-total), not ".roll" -- core puts "roll" on each individual die
+  // (<li class="roll die d20">), so _addRerollButton() found no .dice-total
+  // and silently bailed, leaving rerolls missing from every chat card.
+  html.find(".dice-roll").each((_i, div) => {
     _addRerollButton($(div));
   });
   
@@ -84,7 +89,7 @@ function getRerollButton(
     .attr("title", game.i18n.localize("swnr.chat.rerollButton"))
     .append($("<i>").addClass("fas fa-redo"));
   rerollButton.on("click", async (ev) => {
-    const rollMode = game.settings.get("core", "rollMode");
+    const rollMode = getChatMessageMode();
     ev.stopPropagation();
     const roll = new Roll(diceRoll);
     await roll.roll();
@@ -95,13 +100,16 @@ function getRerollButton(
       title: flavor,
       isAttack,
     };
-    const chatContent = await renderTemplate(chatTemplate, chatDialogData);
+    const chatContent = await foundry.applications.handlebars.renderTemplate(chatTemplate, chatDialogData);
     const chatData = {
       speaker: ChatMessage.getSpeaker(),
-      roll: JSON.stringify(roll),
+      // "rolls" is the current field; the legacy singular "roll" is no longer
+      // honoured, which left rerolled messages with an empty message.rolls
+      // (breaking Dice So Nice and anything reading rolls off the message).
+      rolls: [roll],
       content: chatContent
     };
-    getDocumentClass("ChatMessage").applyRollMode(chatData, rollMode);
+    applyChatMessageMode(chatData, rollMode);
     getDocumentClass("ChatMessage").create(chatData);
   });
   return rerollButton;
@@ -448,7 +456,7 @@ export async function _onDmgRollClick(event, message) {
       traumaDamage = await traumaDamage.render();
     }
   }
-  const rollMode = game.settings.get("core", "rollMode");
+  const rollMode = getChatMessageMode();
 
   const damageRollTemplate = "systems/swnr/templates/chat/damage-roll.hbs";
   const damageRollData = {
@@ -460,16 +468,15 @@ export async function _onDmgRollClick(event, message) {
     traumaRollRender,
     traumaDamage,
   };
-  const damageRollContent = await renderTemplate(damageRollTemplate, damageRollData);
+  const damageRollContent = await foundry.applications.handlebars.renderTemplate(damageRollTemplate, damageRollData);
   const chatData = {
     speaker: ChatMessage.getSpeaker({ actor }),
     content: damageRollContent,
-    roll: JSON.stringify(damageRoll),
     rolls: [damageRoll],
     content: damageRollContent,
     flavor: payload.flavor,
   };
-  getDocumentClass("ChatMessage").applyRollMode(chatData, rollMode);
+  applyChatMessageMode(chatData, rollMode);
   getDocumentClass("ChatMessage").create(chatData);
 }
 
@@ -1175,7 +1182,7 @@ export async function _onChatCardAction(
 export async function welcomeMessage() {
 		const template = "systems/swnr/templates/chat/welcome.hbs";
 
-		const content = await renderTemplate(template, {});
+		const content = await foundry.applications.handlebars.renderTemplate(template, {});
 		const card = {
 			content,
 			user: game.user.id,

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -23,7 +23,60 @@ export function getDefaultImage(itemType) {
 export function calcMod(value,  bonus=0) {
   const m = (value - 10.5) / 3.5;
   return  Math.min(2, Math.max(-2, Math[m < 0 ? "ceil" : "floor"](m))) + bonus;
-  
+
+}
+
+/*--------------------------------------------*/
+/*  Chat message visibility (v13/v14 compat)  */
+/*--------------------------------------------*/
+
+/**
+ * True when running on a core version that uses the v14 message-mode API.
+ * v14 renamed the "core.rollMode" setting to "core.messageMode" and renamed the
+ * values ("publicroll"->"public", "gmroll"->"gm", "blindroll"->"blind",
+ * "selfroll"->"self"). The old setting is still registered on v14 but reads back
+ * as null, so anything using it silently loses the GM's chosen visibility.
+ * @returns {boolean}
+ */
+function usesMessageMode() {
+  return game.settings.settings.has("core.messageMode");
+}
+
+/**
+ * The configured visibility mode for new chat messages, on either core version.
+ * Use this instead of reading "core.rollMode" directly.
+ * @returns {string} A v14 message mode, or a v13 roll mode on older cores.
+ */
+export function getChatMessageMode() {
+  return usesMessageMode()
+    ? game.settings.get("core", "messageMode")
+    : game.settings.get("core", "rollMode");
+}
+
+/**
+ * Translate a semantic visibility into the value the running core expects.
+ * Lets call sites ask for "gm" without caring that v13 spells it "gmroll".
+ * @param {"public"|"gm"|"blind"|"self"} mode
+ * @returns {string}
+ */
+export function chatMode(mode) {
+  if (usesMessageMode()) return mode;
+  return { public: "publicroll", gm: "gmroll", blind: "blindroll", self: "selfroll" }[mode];
+}
+
+/**
+ * Apply the configured visibility to outgoing chat data, on either core version.
+ * Replaces direct calls to the deprecated ChatMessage.applyRollMode().
+ * @param {object} chatData  Chat data to be mutated in place.
+ * @param {string} [mode]    Mode to apply; defaults to the configured one.
+ * @returns {object} The mutated chat data.
+ */
+export function applyChatMessageMode(chatData, mode) {
+  const ChatMessageClass = getDocumentClass("ChatMessage");
+  const resolved = mode ?? getChatMessageMode();
+  return usesMessageMode()
+    ? ChatMessageClass.applyMode(chatData, resolved)
+    : ChatMessageClass.applyRollMode(chatData, resolved);
 }
 
 /*--------------------------------------------*/

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -241,7 +241,7 @@ export class SWNActorSheet extends SWNBaseSheet {
         context.tab = context.tabs[partId];
         // Enrich biography info for display
         // Enrichment turns text like `[[/r 1d20]]` into buttons
-        context.enrichedBiography = await TextEditor.enrichHTML(
+        context.enrichedBiography = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
           this.actor.system.biography,
           {
             // Whether to show secret blocks in the finished html

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1,7 +1,7 @@
 import { prepareActiveEffectCategories } from '../helpers/effects.mjs';
 import { getGameSettings } from '../helpers/register-settings.mjs';
 import { headerFieldWidget, groupFieldWidget } from '../helpers/handlebar.mjs';
-import { initSkills, initCompendSkills, calcMod } from '../helpers/utils.mjs';
+import { initSkills, initCompendSkills, calcMod, chatMode } from '../helpers/utils.mjs';
 import { SWNBaseSheet } from './base-sheet.mjs';
 
 
@@ -213,7 +213,7 @@ export class SWNActorSheet extends SWNBaseSheet {
     };
 
     // Ensure shared fragments are preloaded regardless of which parts render
-    await loadTemplates([
+    await foundry.applications.handlebars.loadTemplates([
       'systems/swnr/templates/actor/fragments/pools-display.hbs'
     ]);
 
@@ -989,7 +989,7 @@ export class SWNActorSheet extends SWNBaseSheet {
       return;
     };
     const template = "systems/swnr/templates/dialogs/add-bulk-skills.hbs";
-    const content = await renderTemplate(template, {});
+    const content = await foundry.applications.handlebars.renderTemplate(template, {});
 
     const _resp = await foundry.applications.api.DialogV2.prompt(
       {
@@ -1057,7 +1057,7 @@ export class SWNActorSheet extends SWNBaseSheet {
         return s + v.mod;
       }, 0),
     };
-    const chatContent = await renderTemplate(
+    const chatContent = await foundry.applications.handlebars.renderTemplate(
       "systems/swnr/templates/chat/stat-block.hbs",
       data
     );
@@ -1065,7 +1065,7 @@ export class SWNActorSheet extends SWNBaseSheet {
     chatMessage.create(
       {
         speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-        roll: JSON.stringify(roll.toJSON()),
+        rolls: [roll],
         content: chatContent
       }
     );
@@ -1124,7 +1124,8 @@ export class SWNActorSheet extends SWNBaseSheet {
         { temporary: true }
       ));
   
-      const { results } = await rollTable.draw({ rollMode: CONST.DICE_ROLL_MODES.PRIVATE });
+      // CONST.DICE_ROLL_MODES is deprecated since v14 (removed in v16).
+      const { results } = await rollTable.draw({ rollMode: chatMode("gm") });
   
       await this.actor.update({
         "system.reaction": results[0].id?.split("0")[0],
@@ -1244,7 +1245,7 @@ export class SWNActorSheet extends SWNBaseSheet {
     const currencyIdx = target.dataset.currencyIdx;
     const currency = this.actor.system.credits.extraCurrencies[currencyIdx];
     const template = "systems/swnr/templates/dialogs/add-currency-type.hbs";
-    const content = await renderTemplate(template, { settings: getGameSettings(), currency: currency });
+    const content = await foundry.applications.handlebars.renderTemplate(template, { settings: getGameSettings(), currency: currency });
     const _resp = await foundry.applications.api.DialogV2.wait(
       {
         window: {
@@ -1356,7 +1357,7 @@ export class SWNActorSheet extends SWNBaseSheet {
   static async _onAddCurrency(event, target) {
     event.preventDefault();
     const template = "systems/swnr/templates/dialogs/add-currency-type.hbs";
-    const content = await renderTemplate(template, { settings: getGameSettings(), currency: {} });
+    const content = await foundry.applications.handlebars.renderTemplate(template, { settings: getGameSettings(), currency: {} });
 
     const _resp = await foundry.applications.api.DialogV2.prompt(
       {

--- a/module/sheets/base-sheet.mjs
+++ b/module/sheets/base-sheet.mjs
@@ -205,7 +205,7 @@ export class SWNBaseSheet extends api.HandlebarsApplicationMixin(
         dragleave: this._onDragLeave.bind(this),
         drop: this._onDrop.bind(this),
       };
-      return new DragDrop(d);
+      return new foundry.applications.ux.DragDrop.implementation(d);
     });
   }
 
@@ -768,7 +768,7 @@ export class SWNBaseSheet extends api.HandlebarsApplicationMixin(
    * @protected
    */
   async _onDrop(event, target) {
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     const actor = this.actor;
     const allowed = Hooks.call('dropActorSheetData', actor, this, data);
     if (allowed === false) return;

--- a/module/sheets/base-sheet.mjs
+++ b/module/sheets/base-sheet.mjs
@@ -1,5 +1,6 @@
 const { api, sheets } = foundry.applications;
 import { ContainerHelper } from '../helpers/container-helper.mjs';
+import { getChatMessageMode } from '../helpers/utils.mjs';
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
@@ -524,7 +525,7 @@ export class SWNBaseSheet extends api.HandlebarsApplicationMixin(
       await roll.toMessage({
         speaker: ChatMessage.getSpeaker({ actor: this.actor }),
         flavor: label,
-        rollMode: game.settings.get('core', 'rollMode'),
+        rollMode: getChatMessageMode(),
       });
       return roll;
     }

--- a/module/sheets/cyberdeck-sheet.mjs
+++ b/module/sheets/cyberdeck-sheet.mjs
@@ -2,6 +2,7 @@ import { getGameSettings } from '../helpers/register-settings.mjs';
 import { headerFieldWidget, groupFieldWidget } from '../helpers/handlebar.mjs';
 
 import { SWNBaseSheet } from './base-sheet.mjs';
+import { getChatMessageMode } from '../helpers/utils.mjs';
 
 const { api, sheets } = foundry.applications;
 
@@ -253,10 +254,10 @@ export class SWNCyberdeckSheet extends SWNBaseSheet {
       pool: CONFIG.SWN.pool,
     };
     const template = "systems/swnr/templates/dialogs/roll-skill-crew.hbs";
-    const html = await renderTemplate(template, dialogData);
+    const html = await foundry.applications.handlebars.renderTemplate(template, dialogData);
 
     const _rollForm = async (_event, button, html) => {
-      const rollMode = game.settings.get("core", "rollMode");
+      const rollMode = getChatMessageMode();
       const dice = button.form.elements.dicepool.value;
       const modifier = parseInt(
         button.form.elements.modifier?.value

--- a/module/sheets/faction-sheet.mjs
+++ b/module/sheets/faction-sheet.mjs
@@ -294,7 +294,7 @@ export class SWNFactionSheet extends SWNBaseSheet {
       effect: tag?.effect ?? "",
     }
     const template = "systems/swnr/templates/dialogs/edit-faction-tag.hbs";
-    const html = await renderTemplate(template, dialogData);
+    const html = await foundry.applications.handlebars.renderTemplate(template, dialogData);
     
     const _modifyTags = async (_event, button, _html) => {
       const name = button.form.elements.tagName.value;
@@ -349,7 +349,7 @@ export class SWNFactionSheet extends SWNBaseSheet {
       tags: CONFIG.SWN.factionTags
     }
     const template = "systems/swnr/templates/dialogs/select-faction-tag.hbs";
-    const html = await renderTemplate(template, dialogData);
+    const html = await foundry.applications.handlebars.renderTemplate(template, dialogData);
     
     const _modifyTags = async (_event, button, _html) => {
       const selectedTagIndex = parseInt(button.form.elements.selectedTag.value);

--- a/module/sheets/faction-sheet.mjs
+++ b/module/sheets/faction-sheet.mjs
@@ -123,7 +123,7 @@ export class SWNFactionSheet extends SWNBaseSheet {
       case 'description':
         // Enrich description info for display
         // Enrichment turns text like `[[/r 1d20]]` into buttons
-        context.enrichedDescription = await TextEditor.enrichHTML(
+        context.enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
             this.actor.system.description,
             {
               // Whether to show secret blocks in the finished html

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -901,7 +901,7 @@ export class SWNItemSheet extends api.HandlebarsApplicationMixin(
    * @protected
    */
   async _onDrop(event) {
-    const data = TextEditor.getDragEventData(event);
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
     const item = this.item;
     const allowed = Hooks.call('dropItemSheetData', item, this, data);
     if (allowed === false) return;
@@ -1046,7 +1046,7 @@ export class SWNItemSheet extends api.HandlebarsApplicationMixin(
         dragover: this._onDragOver.bind(this),
         drop: this._onDrop.bind(this),
       };
-      return new DragDrop(d);
+      return new foundry.applications.ux.DragDrop.implementation(d);
     });
   }
 }

--- a/module/sheets/vehicle-sheet.mjs
+++ b/module/sheets/vehicle-sheet.mjs
@@ -199,7 +199,7 @@ export class SWNVehicleSheet extends SWNBaseSheet {
         context.tab = context.tabs[partId];
         // Enrich notes info for display
         // Enrichment turns text like `[[/r 1d20]]` into buttons
-        context.enrichedDescription = await TextEditor.enrichHTML(
+        context.enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
           this.actor.system.description,
           {
             // Whether to show secret blocks in the finished html
@@ -211,7 +211,7 @@ export class SWNVehicleSheet extends SWNBaseSheet {
           }
         );
 
-        context.enrichedMods = await TextEditor.enrichHTML(
+        context.enrichedMods = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
           this.actor.system.mods,
           {
             // Whether to show secret blocks in the finished html

--- a/module/sheets/vehicle-sheet.mjs
+++ b/module/sheets/vehicle-sheet.mjs
@@ -967,9 +967,9 @@ export class SWNVehicleSheet extends SWNBaseSheet {
       }
       const rollType = button.form.elements.rollType.value;
       if (
-        rollType != "roll" &&
-        rollType != "gmroll" &&
-        rollType != "blindroll"
+        rollType != "public" &&
+        rollType != "gm" &&
+        rollType != "blind"
       ) {
         ui.notifications?.error("Error with roll type");
         return;

--- a/module/sheets/vehicle-sheet.mjs
+++ b/module/sheets/vehicle-sheet.mjs
@@ -1659,11 +1659,13 @@ export class SWNVehicleSheet extends SWNBaseSheet {
     const itemId = target.dataset.itemId || target.closest('[data-item-id]')?.dataset.itemId;
     if (!itemId) return;
 
-    // Toggle the expanded state
-    if (this._expandedDescriptions[itemId]) {
-      delete this._expandedDescriptions[itemId];
+    // ApplicationV2 invokes static action handlers with `this` bound to the
+    // application INSTANCE, which does not inherit static class fields. Reference
+    // the class explicitly, as SWNActorSheet and SWNFactionSheet already do.
+    if (SWNVehicleSheet._expandedDescriptions[itemId]) {
+      delete SWNVehicleSheet._expandedDescriptions[itemId];
     } else {
-      this._expandedDescriptions[itemId] = true;
+      SWNVehicleSheet._expandedDescriptions[itemId] = true;
     }
 
     // Find and toggle the description row
@@ -1672,7 +1674,7 @@ export class SWNVehicleSheet extends SWNBaseSheet {
 
     const descriptionRow = itemRow.nextElementSibling;
     if (descriptionRow && descriptionRow.classList.contains('item-description')) {
-      const isExpanded = this._expandedDescriptions[itemId];
+      const isExpanded = SWNVehicleSheet._expandedDescriptions[itemId];
       descriptionRow.style.display = isExpanded ? 'block' : 'none';
     }
   }

--- a/module/sheets/vehicle-sheet.mjs
+++ b/module/sheets/vehicle-sheet.mjs
@@ -2,6 +2,7 @@ import { prepareActiveEffectCategories } from '../helpers/effects.mjs';
 import { getGameSettings } from '../helpers/register-settings.mjs';
 import { headerFieldWidget, groupFieldWidget, groupFieldWidgetDupe} from '../helpers/handlebar.mjs';
 import { SWNBaseSheet } from './base-sheet.mjs';
+import { getChatMessageMode } from '../helpers/utils.mjs';
 
 const { api, sheets } = foundry.applications;
 
@@ -578,10 +579,10 @@ export class SWNVehicleSheet extends SWNBaseSheet {
       pool: CONFIG.SWN.pool,
     };
     const template = "systems/swnr/templates/dialogs/roll-skill-crew.hbs";
-    const html = await renderTemplate(template, dialogData);
+    const html = await foundry.applications.handlebars.renderTemplate(template, dialogData);
 
     const _rollForm = async (_event, button, html) => {
-      const rollMode = game.settings.get("core", "rollMode");
+      const rollMode = getChatMessageMode();
       const dice = button.form.elements.dicepool.value;
       const modifier = parseInt(
         button.form.elements.modifier?.value
@@ -939,7 +940,7 @@ export class SWNVehicleSheet extends SWNBaseSheet {
     };
 
     const template = "systems/swnr/templates/dialogs/roll-sensor.hbs";
-    const html = renderTemplate(template, dialogData);
+    const html = foundry.applications.handlebars.renderTemplate(template, dialogData);
     const _rollForm = async (_event, button, _html) => {
       const mod = parseInt(
         button.form.elements.modifier?.value
@@ -1088,7 +1089,7 @@ export class SWNVehicleSheet extends SWNBaseSheet {
     };
 
     const template = "systems/swnr/templates/dialogs/roll-spike.hbs";
-    const html = renderTemplate(template, dialogData);
+    const html = foundry.applications.handlebars.renderTemplate(template, dialogData);
 
     const _rollForm = async (_event, button, _html) => {
       const mod = parseInt(
@@ -1187,7 +1188,7 @@ export class SWNVehicleSheet extends SWNBaseSheet {
     });
     const dialogData = {};
     const template = "systems/swnr/templates/dialogs/roll-ship-failure.hbs";
-    const html = renderTemplate(template, dialogData);
+    const html = foundry.applications.handlebars.renderTemplate(template, dialogData);
 
     const _rollForm = async (_event, button, html) => {
       const incDrive = button.form.elements.incdrive?.checked
@@ -1282,7 +1283,7 @@ export class SWNVehicleSheet extends SWNBaseSheet {
   static async _onCrewNPCRoll(event, target) {
     event.preventDefault();
     // Roll skill, show name, skill, attr if != ""
-    const rollMode = game.settings.get("core", "rollMode");
+    const rollMode = getChatMessageMode();
     const formula = `2d6 + @npcCrewSkill`;
     const npcCrewSkill = this.actor.system.crewSkillBonus
       ? this.actor.system.crewSkillBonus
@@ -1551,7 +1552,7 @@ export class SWNVehicleSheet extends SWNBaseSheet {
               skillLevel = defaultActor.system.skillBonus;
             }
             // Roll skill, show name, skill, attr if != ""
-            const rollMode = game.settings.get("core", "rollMode");
+            const rollMode = getChatMessageMode();
             const formula = `${dicePool} + @skillLevel + @attrMod`;
             const roll = new Roll(formula, {
               skillLevel,
@@ -1573,7 +1574,7 @@ export class SWNVehicleSheet extends SWNBaseSheet {
           skillLevel = this.actor.system.crewSkillBonus
             ? this.actor.system.crewSkillBonus
             : 0;
-          const rollMode = game.settings.get("core", "rollMode");
+          const rollMode = getChatMessageMode();
           const formula = `${dicePool} + @skillLevel`;
           const roll = new Roll(formula, {
             skillLevel,

--- a/module/swnr.mjs
+++ b/module/swnr.mjs
@@ -108,7 +108,12 @@ Hooks.once('init', function () {
   // if the transfer property on the Active Effect is true.
   CONFIG.ActiveEffect.legacyTransferral = false;
 
-  // Register sheet application classes
+  // Register sheet application classes.
+  // The bare Actors/Items/ActorSheet/ItemSheet globals are deprecated since v13
+  // and removed in v15; resolve them from their namespaces instead.
+  const { Actors, Items } = foundry.documents.collections;
+  const { ActorSheet, ItemSheet } = foundry.appv1.sheets;
+
   Actors.unregisterSheet('core', ActorSheet);
   Actors.registerSheet('swnr', SWNActorSheet, {
     makeDefault: true,
@@ -355,8 +360,12 @@ Hooks.on('renderSettingsConfig', (app, html, data) => {
 /* Chat Listeners                               */
 /* -------------------------------------------- */
 
-Hooks.on("renderChatMessage", (message, html, _data) =>
-  chatListeners(message, html)
+// renderChatMessage is deprecated since v13 and removed in v15. Its replacement
+// passes an HTMLElement where the old hook passed jQuery, so wrap it at the
+// boundary: chatListeners() and its helpers are still jQuery-based, and porting
+// them to native DOM is tracked separately from this compatibility pass.
+Hooks.on("renderChatMessageHTML", (message, html, _data) =>
+  chatListeners(message, $(html))
 );
 
 /* -------------------------------------------- */

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "yaml": "^2.8.0"
       },
       "devDependencies": {
+        "globals": "^17.7.0",
         "sass": "^1.53.0"
       }
     },
@@ -263,6 +264,276 @@
         "@parcel/watcher-win32-arm64": "2.5.0",
         "@parcel/watcher-win32-ia32": "2.5.0",
         "@parcel/watcher-win32-x64": "2.5.0"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.0.tgz",
+      "integrity": "sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.0.tgz",
+      "integrity": "sha512-hyZ3TANnzGfLpRA2s/4U1kbw2ZI4qGxaRJbBH2DCSREFfubMswheh8TeiC1sGZ3z2jUf3s37P0BBlrD3sjVTUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.0.tgz",
+      "integrity": "sha512-9rhlwd78saKf18fT869/poydQK8YqlU26TMiNg7AIu7eBp9adqbJZqmdFOsbZ5cnLp5XvRo9wcFmNHgHdWaGYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.0.tgz",
+      "integrity": "sha512-syvfhZzyM8kErg3VF0xpV8dixJ+RzbUaaGaeb7uDuz0D3FK97/mZ5AJQ3XNnDsXX7KkFNtyQyFrXZzQIcN49Tw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.0.tgz",
+      "integrity": "sha512-0VQY1K35DQET3dVYWpOaPFecqOT9dbuCfzjxoQyif1Wc574t3kOSkKevULddcR9znz1TcklCE7Ht6NIxjvTqLA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.0.tgz",
+      "integrity": "sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.0.tgz",
+      "integrity": "sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.0.tgz",
+      "integrity": "sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.0.tgz",
+      "integrity": "sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.0.tgz",
+      "integrity": "sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.0.tgz",
+      "integrity": "sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.0.tgz",
+      "integrity": "sha512-+rgpsNRKwo8A53elqbbHXdOMtY/tAtTzManTWShB5Kk54N8Q9mzNWV7tV+IbGueCbcj826MfWGU3mprWtuf1TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@parcel/watcher-win32-x64": {
@@ -1104,6 +1375,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -358,9 +358,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -382,9 +379,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -406,9 +400,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -430,9 +421,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -454,9 +442,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -478,9 +463,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
+    "globals": "^17.7.0",
     "sass": "^1.53.0"
   },
   "dependencies": {

--- a/system.json
+++ b/system.json
@@ -102,7 +102,7 @@
   ],
   "compatibility": {
     "minimum": "13.345",
-    "verified": "13.348"
+    "verified": "14.365"
   },
   "esmodules": ["module/swnr.mjs"],
   "styles": ["css/swnr.css"],

--- a/templates/dialogs/roll-sensor.hbs
+++ b/templates/dialogs/roll-sensor.hbs
@@ -65,9 +65,9 @@
     <div class="flex flex-col">
       <label for="rollType">Roll Type: </label>
       <select name="rollType">
-        <option value="roll">Public</option>
-        <option value="gmroll">Private GM</option>
-        <option value="blindroll" selected>Blind GM Roll</option>
+        <option value="public">Public</option>
+        <option value="gm">Private GM</option>
+        <option value="blind" selected>Blind GM Roll</option>
       </select>
 
     </div>


### PR DESCRIPTION
Brings the system up to Foundry VTT **v14.365**. `minimum` stays at `13.345` — every change works on both v13 and v14, so this is not a breaking release for v13 users.

The first three commits are cherry-picked from @illyja's fork (authorship preserved); the last is the remainder of the pass.

## Why this is needed

On v14 today the system is **broken in ways that are easy to miss**, because Foundry logs deprecations at `error` level and the genuine failures are caught and swallowed.

| Symptom on v14 | Cause |
|---|---|
| Actors can't be created or loaded | `prepareBaseData()` overrode core without `super`, skipping `_clearData()` |
| **Private/blind GM rolls broadcast to all players** | `core.rollMode` setting renamed to `core.messageMode`; old key reads back `null` |
| Reroll buttons missing from every chat card | `.roll` is now on each die, not the roll container |
| Rolls missing from several chat cards | legacy singular `roll:` field no longer honoured |
| Creating a weapon throws | `migrateData()` read `data.trauma.rating` on partial source data |

The message-visibility one is the most serious: a GM selecting *Private GM Roll* or *Blind GM Roll* had that roll posted publicly. Verified directly — with the setting unresolvable, chat data came out as `{blind: false, whisper: []}` for **all four** visibility modes.

## What changed

**Fixes**
- `prepareBaseData()` / `prepareDerivedData()` call `super` (@illyja)
- `migrateData()` guards partial weapon data (@illyja)
- Chat visibility resolves through new helpers in `helpers/utils.mjs` — `getChatMessageMode()`, `applyChatMessageMode()`, `chatMode()` — which pick the correct setting key and API per core version (18 read sites, 11 apply sites)
- `chatListeners()` targets `.dice-roll` instead of `.roll`
- All chat senders use `rolls: [...]`; redundant legacy `roll:` lines removed

**Deprecations** (removed in v15/v16)
- Namespaced globals: document collections + AppV1 sheet classes, `renderTemplate`/`loadTemplates` (26 sites), `TextEditor`, `DragDrop` (last two @illyja)
- `renderChatMessage` → `renderChatMessageHTML`
- `ChatMessage.applyRollMode()`, `CONST.DICE_ROLL_MODES`
- `compatibility.verified` → `14.365` (@illyja)

**Docs**
- `CLAUDE.md` gains a v13/v14 compatibility reference (version target, namespaced-globals table, document lifecycle, chat conventions)
- `AGENTS.md` / `GEMINI.md` stop claiming v13-only and point at `CLAUDE.md` instead of keeping diverging copies
- @illyja added to contributors

## Deliberately out of scope

`chatListeners()` and its helpers are ~250 lines of jQuery. The **deprecated thing is the hook name**, not the jQuery, so the new hook's `HTMLElement` is wrapped at the boundary and the jQuery port is left for its own PR — it's a behavioural refactor and it overlaps open PR #217, which rewrites part of the same surface.

`CONFIG.ActiveEffect.legacyTransferral` is left in place: v14 core no longer reads it, but v13 does, and removing it would silently change v13 behaviour.

## Verification

Live in a v14.365 world: world launch, actor create + load, actor and item sheet render, weapon create, roll, and reroll. Console went from **14 messages including a fatal data-preparation error to zero** — no deprecations, no errors. Message visibility confirmed correct for `public` / `gm` / `blind` / `self`.

Not covered by manual testing: vehicle/ship/cyberdeck/faction sheets and the power-consumption flows. Those files are touched only by mechanical substitutions (`renderTemplate`, `rollMode`), but they deserve a playtest before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
