### PR TITLE
Don't run the migration wrapper when there is nothing to migrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,46 +22,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Foundry VTT v14 compatibility
 
-Verified against Foundry v14.365. Minimum supported core remains 13.345 — everything below
-works on both v13 and v14.
+Verified against Foundry v14.365. Minimum supported core remains 13.345.
 
-#### Fixes
-- **Actors could not be created or loaded on v14.** `SWNActor.prepareBaseData()` overrode
-  core without calling `super`, skipping the `_clearData()` that initializes
-  `tokenActiveEffectChanges`, so active-effect application threw during document
-  initialization. (Thanks @illyja)
-- **Private and blind rolls were posted publicly on v14.** v14 renamed the `core.rollMode`
-  setting to `core.messageMode` and changed its values; the old key still exists but reads
-  back `null`, so every chat message was built with no whisper targets regardless of the
-  GM's selected mode. Visibility now resolves through version-aware helpers.
-- **Reroll buttons never appeared on v14.** The handler selected `.roll`, which core now
-  puts on each individual die rather than the roll container (`.dice-roll`).
-- **Rolls were missing from several chat cards.** Messages using the legacy singular
-  `roll:` field produced an empty `message.rolls` (breaking Dice So Nice and anything
-  reading rolls off the message); all senders now use `rolls: [...]`.
-- Creating a new weapon threw on partial source data in `migrateData()`. (Thanks @illyja)
-- **The ship sensor roll never posted on v14.** Its dialog offered hardcoded v13 mode
-  strings and passed them into the chat API, which rejects unrecognised modes; the roll
-  threw before reaching chat. The same message also set the message-style enum on `type`
-  (the document subtype, which only accepts `"base"`) rather than `style`, which made
-  `create()` silently fail. Both fixed; public, private and blind sensor rolls all work.
-- Ship weapon migration aborted halfway on any item predating the `trauma` field — the
-  same unguarded access already fixed for weapons. Because core wraps `migrateData()` in a
-  try/catch this failed silently, skipping the stat migration below it.
-- Power chat cards were not roll messages (no Dice So Nice, empty `rolls`); they were the
-  last holdout still using the legacy singular `roll:` field.
-
-#### Compatibility
-- Migrated deprecated globals removed in v15 to their namespaces: document collections and
-  AppV1 sheet classes, `renderTemplate`/`loadTemplates`, `TextEditor`, and `DragDrop`.
-  (`TextEditor`/`DragDrop` thanks @illyja)
-- Moved from the deprecated `renderChatMessage` hook to `renderChatMessageHTML`.
-- Replaced `ChatMessage.applyRollMode()` and `CONST.DICE_ROLL_MODES` (deprecated in v14).
-- System now loads with no deprecation warnings or errors on v14.
-
-#### Docs
-- `CLAUDE.md` documents the v13/v14 compatibility rules; `AGENTS.md` and `GEMINI.md` now
-  point at it instead of keeping their own drifting copies.
+- Fixed actors failing to create or load on v14 (Thanks @illyja)
+- Fixed private and blind rolls being posted publicly on v14
+- Fixed reroll buttons not appearing on chat cards
+- Fixed missing rolls on several chat cards, including power cards (no Dice So Nice, empty `rolls`)
+- Fixed creating a new weapon throwing on partial data (Thanks @illyja)
+- Fixed the ship sensor roll never posting to chat
+- Fixed ship weapon migration silently aborting on items predating the trauma field
+- Fixed vehicle sheet item descriptions throwing on every expand click
+- Replaced deprecated globals removed in v15, the `renderChatMessage` hook, and the roll mode APIs deprecated in v14 (`TextEditor`/`DragDrop` thanks @illyja)
+- System now loads with no deprecation warnings or errors on v14
+- Contributor docs (`CLAUDE.md`) now cover the v13/v14 rules, with `AGENTS.md` and `GEMINI.md` pointing at it
 
 ## [2.3.0] 2025-11-04 More XWN support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added save modifiers to character sheet (under features/tweaks)
 - Fixed issue with vacc suit and skin descriptions
 - Stowed currency encumbrance now only counts carried currencies (bug fix)
+- Right-click a chat message roll to apply it to the selected token(s) as damage, modified damage, half damage, or healing (Thanks @pandanielxd)
+- Fixed end ship round not updating command points, actions taken, or supporting department (Thanks @gvigh)
+- Upgrades with no data migrations no longer show the migration warning notifications
+- Failed migrations are now retried on the next load instead of being marked complete (bug fix)
 
 ### Foundry VTT v14 compatibility
 

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -3,11 +3,23 @@
  * @returns {Promise} A Promise which resolves once the migration is completed
  */
 export const migrateWorld = async function (storedVersion) {
+  const pendingVersions = getPendingMigrations(storedVersion);
+
+  // Most releases ship no data migrations at all. Telling the GM not to shut down
+  // their server while we do nothing is alarming and unnecessary -- just record the
+  // new version and show them what changed.
+  if (!pendingVersions.length) {
+    console.log(`SWNR | No data migrations between ${storedVersion} and ${game.system.version}`);
+    await game.settings.set("swnr", "systemMigrationVersion", game.system.version);
+    await showReleaseNotesToGM();
+    return;
+  }
+
   ui.notifications.info(`Applying SWN/CWN/AWN System Migration for version ${game.system.version}. Please be patient and do not close your game or shut down your server.`, { permanent: true });
 
   try {
     // Migrate world depending on the version of the system
-    await runMigrationsSequentially(storedVersion);
+    await runMigrationsSequentially(pendingVersions);
 
     // Set the migration as complete only if all migrations succeeded
     await game.settings.set("swnr", "systemMigrationVersion", game.system.version);
@@ -23,20 +35,26 @@ export const migrateWorld = async function (storedVersion) {
 };
 
 /**
- * Runs migration functions sequentially, starting from the stored version
- * up to the latest version defined in the migrations object.
- *
- * This function first filters the migration versions to only those that are
- * greater than the currently stored version, then sorts them in ascending order.
- * It then iterates through each version and awaits the corresponding migration function,
- * ensuring that migrations are applied in the correct order.
+ * Lists the migrations that still need to run, i.e. those keyed to a version
+ * greater than the stored one, in ascending order.
  *
  * @param {string} storedVersion - The version number from which to start migrations.
- * @returns {Promise<void>} A Promise that resolves once all applicable migrations have been executed.
+ * @returns {string[]} The applicable migration versions, oldest first.
  */
-async function runMigrationsSequentially(storedVersion) {
-  const versions = Object.keys(migrations).filter(key => compareVersions(key, storedVersion) > 0).sort((a, b) => compareVersions(a, b));
+function getPendingMigrations(storedVersion) {
+  return Object.keys(migrations)
+    .filter(key => compareVersions(key, storedVersion) > 0)
+    .sort((a, b) => compareVersions(a, b));
+}
 
+/**
+ * Runs the given migration functions sequentially, awaiting each one so that they
+ * are applied in order.
+ *
+ * @param {string[]} versions - Migration versions to run, oldest first.
+ * @returns {Promise<void>} A Promise that resolves once all migrations have been executed.
+ */
+async function runMigrationsSequentially(versions) {
   for (const version of versions) {
     await migrations[version]();
   }

--- a/module/swnr.mjs
+++ b/module/swnr.mjs
@@ -202,7 +202,7 @@ function initializeLanguageSettings() {
 /*  Ready Hook                                  */
 /* -------------------------------------------- */
 
-Hooks.once('ready', function () {
+Hooks.once('ready', async function () {
   // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
   Hooks.on('hotbarDrop', (_bar, data, slot) => {
 
@@ -218,21 +218,6 @@ Hooks.once('ready', function () {
     return;
   }
 
-  const storedVersion = game.settings.get('swnr', 'systemMigrationVersion');
-  const currentVersion = game.system.version;
-
-  // If there's no stored version, set it to the current system version (and don't migrate)
-  if (!storedVersion) {
-    return game.settings.set('swnr', 'systemMigrationVersion', currentVersion);
-  }
-
-  // If the stored version doesn't match the current system version, run migration
-  if (storedVersion !== currentVersion) {
-    welcomeMessage();
-    migrations.migrateWorld(storedVersion);
-    game.settings.set('swnr', 'systemMigrationVersion', currentVersion);
-  }
-
   // Initialize language settings on first load
   initializeLanguageSettings();
 
@@ -244,6 +229,29 @@ Hooks.once('ready', function () {
     }
     return originalGetInitiativeRoll.call(this);
   };
+
+  // Migration runs last: it awaits, and nothing above should wait on it.
+  const storedVersion = game.settings.get('swnr', 'systemMigrationVersion');
+  const currentVersion = game.system.version;
+
+  // If there's no stored version, set it to the current system version (and don't migrate)
+  if (!storedVersion) {
+    return game.settings.set('swnr', 'systemMigrationVersion', currentVersion);
+  }
+
+  // If the stored version doesn't match the current system version, run migration
+  if (storedVersion !== currentVersion) {
+    welcomeMessage();
+    try {
+      // migrateWorld stores the new version itself, and only on success -- writing it
+      // here as well would mark a failed migration complete and stop it retrying.
+      await migrations.migrateWorld(storedVersion);
+    } catch (err) {
+      // migrateWorld has already notified the GM and left systemMigrationVersion
+      // untouched, so the migration is retried on the next load.
+      console.error('SWNR | World migration failed', err);
+    }
+  }
 });
 
 /* -------------------------------------------- */


### PR DESCRIPTION
Two migration problems that the 2.3.1 version bump would surface, plus changelog upkeep.

### 1. The no-op migration is loud and alarming

`migrateWorld()` raised its permanent *"do not close your game or shut down your server"* notification **before** working out whether there was anything to do. The `migrations` map tops out at `2.3.0`, so bumping `system.json` to `2.3.1` would give every GM that warning, then a permanent *"completed!"*, for zero work.

`getPendingMigrations()` is now split out of `runMigrationsSequentially()` so the list can be checked first. Empty list → record the version, show the release notes, return. Non-empty → unchanged, notifications and all.

### 2. A failed migration was marked complete (bug)

`module/swnr.mjs` did:

```js
migrations.migrateWorld(storedVersion);                              // not awaited
game.settings.set('swnr', 'systemMigrationVersion', currentVersion); // runs regardless
```

`migrateWorld()` stores the version itself, and deliberately only on success — it rethrows on failure precisely so the migration retries on the next load. The unawaited call plus the unconditional write on the next line defeated that: a migration that threw still got stamped as done, so the world stayed half-migrated and never tried again.

Now awaited, with the redundant write removed. The `catch` is there only so a failure doesn't surface as an unhandled rejection — `migrateWorld` has already notified the GM by that point.

### 3. Knock-on: the migration block moved to the end of the `ready` hook

Awaiting in place would have delayed the `getInitiativeRoll` override until migration finished, leaving a window where combat started mid-migration uses core initiative.

The move also fixes a pre-existing bug: `if (!storedVersion) return ...` sat **above** `initializeLanguageSettings()` and the initiative override, so a brand-new world skipped both for its entire first session. That early return is now last in the function.

### Verified

In a live 14.365 world, importing the module fresh and calling `migrateWorld(game.system.version)`: **0 notifications** before and after, version recorded, release-notes journal rendered. That is exactly the 2.3.0 → 2.3.1 path.

The failure path is not exercised — forcing a throw means half-writing real actor data. It is structural: `migrateWorld`'s `catch` was already correct and is untouched; the only thing breaking it was the caller.

### Changelog

Entries for this, #212 and #217, plus the v14 section trimmed to the one-line depth the rest of the file uses (it was 39 lines of mechanism, which ships verbatim into every GM's release-notes journal via `compile-release-notes`). One missing entry added along the way — 202875da, the vehicle sheet item-description toggle, was never recorded.

The `TODO` lines in the 2.3.1 section are left alone.