### PR TITLE
Fix two v14 regressions still open against 2.3.1 (#222, #213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added save modifiers to character sheet (under features/tweaks)
 - Fixed issue with vacc suit and skin descriptions
 - Stowed currency encumbrance now only counts carried currencies (bug fix)
+- Fixed ship, vehicle, mech, and drone weapon attacks throwing when the trauma setting is enabled
 
 ### Foundry VTT v14 compatibility
 
@@ -36,6 +37,10 @@ works on both v13 and v14.
   `roll:` field produced an empty `message.rolls` (breaking Dice So Nice and anything
   reading rolls off the message); all senders now use `rolls: [...]`.
 - Creating a new weapon threw on partial source data in `migrateData()`. (Thanks @illyja)
+- **Weapon sheets could not be opened from a character sheet on v14.** The skill dropdown
+  used the `{{#select}}` block helper, which core removed in v14, so the sheet failed with
+  `Missing helper: "select"`. It now builds its options with `selectOptions`, matching the
+  ammo dropdown beside it.
 - **The ship sensor roll never posted on v14.** Its dialog offered hardcoded v13 mode
   strings and passed them into the chat API, which rejects unrecognised modes; the roll
   threw before reaching chat. The same message also set the message-style enum on `type`

--- a/module/data/items/item-ship-weapon.mjs
+++ b/module/data/items/item-ship-weapon.mjs
@@ -259,7 +259,7 @@ export default class SWNShipWeapon extends SWNVehicleItemBase {
         this.trauma.die !== "none" &&
         this.trauma.rating != null
       ) {
-        const traumaRoll = new Roll(this.system.trauma.die);
+        const traumaRoll = new Roll(this.trauma.die);
         await traumaRoll.roll();
         traumaRollRender = await traumaRoll.render();
         if (

--- a/module/helpers/register-settings.mjs
+++ b/module/helpers/register-settings.mjs
@@ -271,7 +271,7 @@ export const registerSettings = function () {
     config: true,
     type: Number,
     default: -1,
-    equiresReload: true,
+    requiresReload: true,
   });
 
   // Currency Settings----------------------------------------------------------

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -602,9 +602,15 @@ export class SWNItemSheet extends api.HandlebarsApplicationMixin(
     // Get the related items for the owning parent (if any) for ammo
     const item = this.item;
     let ammo = [];
+    // Skill choices are built here rather than in the template because the label
+    // combines two fields (name and rank), which selectOptions cannot compose.
+    const skills = {};
     const parent = item.parent;
     if (parent && parent.type === 'character' && item.type === 'weapon') {
       //console.log(`Getting related items for ${item.name} with parent ${parent.name}`);
+      for (const skill of parent.itemTypes.skill) {
+        skills[skill.id] = `${skill.name} ${skill.system.rank}`;
+      }
       // Get the related
       const ammoType = item.system.ammo?.type;
       //console.log(`Ammo type for ${item.name} is ${ammoType}`);
@@ -616,7 +622,7 @@ export class SWNItemSheet extends api.HandlebarsApplicationMixin(
     }
     const related = {
       ammo: ammo,
-
+      skills: skills,
     };
     return related;
   }

--- a/templates/item/attribute-parts/weapon.hbs
+++ b/templates/item/attribute-parts/weapon.hbs
@@ -46,19 +46,9 @@
     <div class="resource">
       {{#if item.parent}}
       {{#if (eq item.parent.type 'character')}}
-      {{!-- {{selectOptions item.parent.itemTypes.skill selected=item.skill labelAttr="skill" valueAttr="skill"
-      blank=""}} --}}
-      {{!-- {{formGroup systemFields.skill value=system.skill localize=true}} --}}
-
       <label>{{localize 'swnr.sheet.skill'}}:</label>
       <select name="system.skill">
-        {{#select system.skill}}
-        <option value="">{{ localize 'swnr.weapon.noSetSkill'}}</option>
-        {{#each item.parent.itemTypes.skill }}
-        <option value="{{this.id}}">
-          {{this.name}} {{this.system.rank}}
-        </option>
-        {{/each}} {{/select}}
+        {{selectOptions related.skills selected=system.skill blank=(localize 'swnr.weapon.noSetSkill')}}
       </select>
       {{/if}}
       {{/if}}


### PR DESCRIPTION
Two bugs found while sweeping the open issues against `dev-2.3.1`, plus a typo in code added this cycle. All three verified live on Foundry 14.365.

## `Missing helper: "select"` — closes #222

`templates/item/attribute-parts/weapon.hbs` still used the `{{#select}}` block helper, which core removed in v14. Confirmed absent from the v14.365 helper registry, and confirmed the exact error in the running world:

```js
Handlebars.compile(`{{#select skill}}<option value="a">A</option>{{/select}}`)({skill:'a'})
// Missing helper: "select"
```

The block sat inside `{{#if item.parent}}`, which is why the reporter's workaround (edit the weapon in the sidebar first) worked — without a parent actor the branch never ran.

Now uses `selectOptions`, matching the ammo dropdown immediately below it. The label combines name and rank, which `selectOptions` can't compose from a single `labelAttr`, so the choices object is built in `_getRelatedItems()` next to the ammo list.

Rendered output is unchanged apart from the fix:

| | before (v13) | after (v14) |
|---|---|---|
| no skill set | `No Skill Set` / `Shoot 2` / `Punch 0` | same |
| skill set | `Shoot 2` marked selected | same |

This also covers the "Embedded weapon sheets fail with `Missing helper: select`" bullet of #230.

## Vehicle weapon rolls throw — closes #213

`module/data/items/item-ship-weapon.mjs` built the trauma roll from `this.system.trauma.die`. `rollAttack` is on the system data model, so `this` **is** the system — `this.system` is undefined. The guard three lines above already reads `this.trauma.die` correctly.

It was the only `this.system.` in all of `module/data/`. Fires whenever `useTrauma` is on and the weapon has a trauma die, matching the reported stack exactly.

Verified by rolling a ship weapon with `useTrauma` on: no throw, card posts, trauma section renders.

## `equiresReload` typo

`unskilledPenalty` in `register-settings.mjs` was missing the leading `r`. Foundry ignores unknown keys on a registration, so it failed silently. The setting is new in 2.3.1, so nothing shipped broken. Verified `game.settings.settings.get('swnr.unskilledPenalty').requiresReload === true`.

## Verification

- Weapon sheet renders on a character with skills, both with and without a skill selected
- Ship weapon attack with trauma enabled posts its card without throwing
- Clean world reload on 14.365: zero console errors, zero deprecation warnings, zero notifications
- No new lint errors (both touched JS files have pre-existing ones; none on the added lines)
- Test actors and chat messages cleaned up; `useTrauma` restored to its registered default

## Note on merge order

This branches off `dev-2.3.1`, so it doesn't include #232. Both touch the 2.3.1 changelog — #232 also rewrites the v14 subsection to be terser. Whichever merges second will want to keep the new "Weapon sheets could not be opened" entry.