### PR TITLE
Namespace the last bare duplicate() calls (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Verified against Foundry v14.365. Minimum supported core remains 13.345.
 - Fixed the ship sensor roll never posting to chat
 - Fixed ship weapon migration silently aborting on items predating the trauma field
 - Fixed vehicle sheet item descriptions throwing on every expand click
+- Fixed editing character resources, custom currencies, and vehicle cargo throwing on v14 (the `duplicate` global was removed, not just deprecated)
 - Replaced deprecated globals removed in v15, the `renderChatMessage` hook, and the roll mode APIs deprecated in v14 (`TextEditor`/`DragDrop` thanks @illyja)
 - System now loads with no deprecation warnings or errors on v14
 - Contributor docs (`CLAUDE.md`) now cover the v13/v14 rules, with `AGENTS.md` and `GEMINI.md` pointing at it

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1167,7 +1167,7 @@ export class SWNActorSheet extends SWNBaseSheet {
     event.preventDefault();
     const dataset = target.dataset;
     const idx = dataset.rlIdx;
-    const resourceList = duplicate(this.actor.system.tweak.resourceList);
+    const resourceList = foundry.utils.duplicate(this.actor.system.tweak.resourceList);
     resourceList.splice(idx, 1);
     await this.actor.update({ "system.tweak.resourceList": resourceList });
   }
@@ -1177,7 +1177,7 @@ export class SWNActorSheet extends SWNBaseSheet {
     const value = event.target?.value;
     const resourceType = $(event.currentTarget).data("rlType");
     const idx = $(event.currentTarget).parents(".item").data("rlIdx");
-    const resourceList = duplicate(this.actor.system.tweak.resourceList);
+    const resourceList = foundry.utils.duplicate(this.actor.system.tweak.resourceList);
     resourceList[idx][resourceType] = value;
     await this.actor.update({ "system.tweak.resourceList": resourceList });
   }
@@ -1272,7 +1272,7 @@ export class SWNActorSheet extends SWNBaseSheet {
               value: currencyValue,
               carried: carried,
             };
-            const currencyList = duplicate(this.actor.system.credits.extraCurrencies);
+            const currencyList = foundry.utils.duplicate(this.actor.system.credits.extraCurrencies);
             currencyList[currencyIdx] = currency;
             await this.actor.update({
               "system.credits.extraCurrencies": currencyList
@@ -1298,7 +1298,7 @@ export class SWNActorSheet extends SWNBaseSheet {
               ui.notifications.info("Currency deletion cancelled");
               return "cancel";
             }
-            const currencyList = duplicate(this.actor.system.credits.extraCurrencies);
+            const currencyList = foundry.utils.duplicate(this.actor.system.credits.extraCurrencies);
             currencyList.splice(currencyIdx, 1);
             await this.actor.update({
               "system.credits.extraCurrencies": currencyList
@@ -1310,7 +1310,7 @@ export class SWNActorSheet extends SWNBaseSheet {
           action: "convert",
           icon: 'fas fa-exchange-alt',
           callback: async (_event, _button, _dialog) => {
-            const currencyList = duplicate(this.actor.system.credits.extraCurrencies);
+            const currencyList = foundry.utils.duplicate(this.actor.system.credits.extraCurrencies);
             const baseCurrencyName = game.settings.get("swnr", "baseCurrencyName");
             const currencyToConvert = currencyList[currencyIdx];
             let baseCurrencyToAdd = 0;

--- a/module/sheets/base-sheet.mjs
+++ b/module/sheets/base-sheet.mjs
@@ -659,7 +659,7 @@ export class SWNBaseSheet extends api.HandlebarsApplicationMixin(
 
           if (currencyType === 'custom') {
             const currencyIdx = target.dataset.currencyIdx;
-            let extraCurrencies = duplicate(this.actor.system.credits.extraCurrencies);
+            let extraCurrencies = foundry.utils.duplicate(this.actor.system.credits.extraCurrencies);
             const currency = extraCurrencies[currencyIdx];
             if (currency == undefined || currency == null) {
               ui.notifications?.error("Invalid currency");

--- a/module/sheets/vehicle-sheet.mjs
+++ b/module/sheets/vehicle-sheet.mjs
@@ -452,7 +452,7 @@ export class SWNVehicleSheet extends SWNBaseSheet {
     const value = event.target?.value;
     const resourceType = event.target.dataset.rlType
     const idx = event.target.dataset.rlIdx;
-    const resourceList = duplicate(this.actor.system.cargoCarried);
+    const resourceList = foundry.utils.duplicate(this.actor.system.cargoCarried);
     resourceList[idx][resourceType] = value;
     await this.actor.update({ "system.cargoCarried": resourceList });
   }
@@ -461,7 +461,7 @@ export class SWNVehicleSheet extends SWNBaseSheet {
     event.preventDefault();
     event.stopPropagation();
     const idx = target.dataset.idx;
-    const resourceList = duplicate(this.actor.system.cargoCarried);
+    const resourceList = foundry.utils.duplicate(this.actor.system.cargoCarried);
     resourceList.splice(idx, 1);
     await this.actor.update({ "system.cargoCarried": resourceList });
   }

--- a/templates/chat/stat-block.hbs
+++ b/templates/chat/stat-block.hbs
@@ -26,7 +26,7 @@
 </table>
 <div class="statApplyButton">
   <button data-actor-id="{{actor.id}}">
-    {{formatMessage (localize 'swnr.chat.statApply') name=actor.name}}
+    {{localize 'swnr.chat.statApply' name=actor.name}}
   </button>
 </div>
 {{!--<pre>{{stringify @root}}</pre> --}}


### PR DESCRIPTION
Follow-up to the issue sweep. One real v14 fix and one small robustness change.

## `duplicate` is removed on v14, not deprecated — closes #105

#105 was filed as a v12 deprecation *warning*. On 14.365 it's worse than that — the global is gone entirely:

```js
'duplicate' in globalThis        // false
eval('duplicate({a:1})')         // ReferenceError: duplicate is not defined
foundry.utils.duplicate({a:1})   // { a: 1 }
```

So these eight call sites were hard failures on v14, not noisy ones:

| Path | Breaks |
|---|---|
| `actor-sheet.mjs:1170,1180` | deleting / editing a character resource row |
| `actor-sheet.mjs:1275,1301,1313`, `base-sheet.mjs:662` | custom currencies |
| `vehicle-sheet.mjs:455,464` | vehicle cargo |

The v14 pass migrated `TextEditor`, `DragDrop`, `renderTemplate` and `loadTemplates` but missed `duplicate` — none of these run at load time, so a clean startup console didn't surface them.

Verified by exercising `_onResourceDelete` against a real character with a populated `resourceList`: no throw, no warnings, row removed. Swept the other `foundry.utils` globals at the same time (`mergeObject`, `getProperty`, `setProperty`, `expandObject`, `flattenObject`, `deepClone`, `randomID`, …) — `duplicate` was the only one left, and the one `expandObject` hit is inside a comment.

## `formatMessage` → `localize` — not a bug fix

I flagged this as a missing helper in the sweep. **That was wrong** — it renders fine, because Foundry bundles `handlebars-intl`, which registers it. `{{formatMessage (localize 'swnr.chat.statApply') name=…}}` produces "Apply stats to Vera Cruz" on 14.365 today.

Changing it anyway, for a weaker reason: `formatMessage` appears nowhere in `foundry.mjs` — it's an undocumented side effect of a bundled dependency, not a Foundry API, so nothing commits to keeping it. `localize` passes its hash straight to `game.i18n.format`, so the one-helper form is equivalent and matches the idiom used everywhere else in the templates (`{{localize 'DOCUMENT.New' type=...}}`).

Output is byte-identical. Happy to drop this commit if you'd rather leave it alone — it's `f026b93f` on its own.

## Verification

- `_onResourceDelete` on a real character: works, zero warnings
- Stat block template renders to "Apply stats to Vera Cruz" both before and after
- No new lint errors — the 4 flagged on touched lines are pre-existing `@stylistic/js/indent` on the surrounding blocks, confirmed against the branch point
- Test actors cleaned up